### PR TITLE
change iloipaddress lookup to find ipv4

### DIFF
--- a/ov/server_hardware.go
+++ b/ov/server_hardware.go
@@ -125,7 +125,8 @@ func (h ServerHardware) GetIloIPAddress() string {
 		if h.MpHostInfo != nil {
 			log.Debug("working on getting IloIPAddress from MpHostInfo")
 			for _, MpIpObj := range h.MpHostInfo.MpIPAddress {
-				if len(MpIpObj.Address) > 0 {
+				if len(MpIpObj.Address) > 0 &&
+					(MpDHCP.Equal(MpIpObj.Type) || MpStatic.Equal(MpIpObj.Type)) {
 					return MpIpObj.Address
 				}
 			}

--- a/ov/server_hardwarev2.go
+++ b/ov/server_hardwarev2.go
@@ -18,6 +18,8 @@ limitations under the License.
 package ov
 
 import (
+	"strings"
+
 	"github.com/HewlettPackard/oneview-golang/liboneview"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/docker/machine/libmachine/log"
@@ -69,15 +71,37 @@ type MpIPAddressv200 struct {
 	Type    string `json:"type,omitempty"`    // type The type of IP address. The following are useful values for the IP address type: Static - Static IP address configuration; DHCP - Dynamic host configuration protocol; SLAAC - Stateless address autoconfiguration (IPv6); LinkLocal - Link-local address (IPv6);
 }
 
-// TODO: needs a type
-// Values
-//     DHCP
-//     LinkLocal
-//     LinkLocal_Required
-//     Lookup
-//     SLAAC
-//     Static
-//     Undefined
+// MpIPTypev200 Type constant
+type MpIPTypev200 int
+
+// const block
+const (
+	MpDHCP MpIPTypev200 = 1 + iota
+	MpLinkLocal
+	MpLinkLocalRequired
+	MpLookup
+	MpSlaaC
+	MpStatic
+	MpUndefined
+)
+
+var mpiptypevlist = [...]string{
+	"DHCP",
+	"LinkLocal",
+	"LinkLocal_Required",
+	"Lookup",
+	"SLAAC",
+	"Static",
+	"Undefined",
+}
+
+// String helper for MpIPTypev200
+func (o MpIPTypev200) String() string { return mpiptypevlist[o-1] }
+
+// Equal helper for MpIPTypev200
+func (o MpIPTypev200) Equal(s string) bool {
+	return (strings.ToUpper(s) == strings.ToUpper(o.String()))
+}
 
 // PortMapv200 -
 type PortMapv200 struct {

--- a/test/data/config_EGSL_tbird200.json
+++ b/test/data/config_EGSL_tbird200.json
@@ -43,7 +43,7 @@
         "TemplateProfile": "docker1.8_server_template",
         "SerialNumber": "VCGHJL900C",
         "UsedBladeName": "HOUEGSL-C7000-04, bay 4",
-        "ServerHardwareURI": "/rest/server-hardware/30373237-3132-4D32-3235-303930524D53",
+        "ServerHardwareURI": "/rest/server-hardware/36343537-3338-4E43-3735-313830303534",
         "ServerProfileName": "houegsl-c7000-04-04",
         "HardwareTypeURI": "/rest/server-hardware-types/1A1EBD9A-6ABE-4D96-BB9C-E9F39876BD3E",
         "GroupURI": "/rest/enclosure-groups/9bf6f6b2-abf5-4875-b72c-4cb6e744691b",
@@ -55,7 +55,8 @@
         "MinimumVersion": 1,
         "FakeData": "foo",
         "IcspName2" : "IC04-HOUEGSL-C7000-04-4",
-        "SerialNumber": "2M25090RMS"
+        "SerialNumber": "2M25090RMS",
+        "IloIPAddress":  "16.85.0.107"
       }
     },
     {


### PR DESCRIPTION
Ilo attach is only working for ipv4, lets limit
ip selection for ipv4 only

Signed-off-by: Edward Raigosa edward.raigosa@hpe.com
