### PR TITLE
fix session logout so we empty the apikey correctly

### DIFF
--- a/icsp/auth.go
+++ b/icsp/auth.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package icsp -
+// Package icsp
+
 package icsp
 
 import (
@@ -29,7 +30,7 @@ import (
 // URLEndPoint export this constant
 const URLEndPointSession = "/rest/login-sessions"
 
-// GetAuthHeaderMap Generate an auth Header map ...
+// GetAuthHeaderMapNoVer Generate an auth Header map ...
 // some api endpoints are hiddent, remove api version to get to them
 func (c *ICSPClient) GetAuthHeaderMapNoVer() map[string]string {
 	return map[string]string{
@@ -103,17 +104,16 @@ func (c *ICSPClient) SessionLogout() error {
 	var (
 		uri = "/rest/login-sessions"
 	)
-
+	log.Debugf("Calling logout for header -> %+v", c.GetAuthHeaderMap())
+	if c.APIKey == "none" {
+		log.Debugf("already logged out")
+		return nil
+	}
 	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
 	_, err := c.RestAPICall(rest.DELETE, uri, nil)
 	if err != nil {
 		return err
 	}
-	c.APIKey = ""
-	// successful logout HTTP status 204 (no content)
+	c.APIKey = "none"
 	return nil
-	/*if err := json.Unmarshal([]byte(data), &session); err != nil {
-		return session, err
-	}
-	*/
 }

--- a/icsp/auth_test.go
+++ b/icsp/auth_test.go
@@ -24,6 +24,12 @@ func TestSessionLogin(t *testing.T) {
 		assert.NoError(t, err, "SessionLogin threw error -> %s", err)
 		assert.NotEmpty(t, data.ID, fmt.Sprintf("SessionLogin is empty! something went wrong, err -> %s, data -> %+v\n", err, data))
 		assert.Equal(t, "none", c.APIKey)
+
+		c.APIKey = data.ID
+		err = c.SessionLogout()
+		assert.NoError(t, err, "SessionLogout threw error -> %s", err)
+		data, err = c.SessionLogin()
+		assert.NoError(t, err, "SessionLogin threw error -> %s", err)
 	} else {
 		_, c = getTestDriverU()
 		data, err := c.SessionLogin()

--- a/ov/auth.go
+++ b/ov/auth.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package ov -
+// Package ov for working with HP OneView
 package ov
 
 import (
@@ -106,17 +106,17 @@ func (c *OVClient) SessionLogout() error {
 	var (
 		uri = "/rest/login-sessions"
 	)
-
+	log.Debugf("Calling logout for header -> %+v", c.GetAuthHeaderMap())
+	if c.APIKey == "none" {
+		log.Debugf("already logged out")
+		return nil
+	}
 	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
 	_, err := c.RestAPICall(rest.DELETE, uri, nil)
 	if err != nil {
+		log.Debugf("Error from %s :-> %+v", uri, err)
 		return err
 	}
-	c.APIKey = ""
-	// successful logout HTTP status 204 (no content)
+	c.APIKey = "none"
 	return nil
-	/*if err := json.Unmarshal([]byte(data), &session); err != nil {
-		return session, err
-	}
-	*/
 }

--- a/ov/auth_test.go
+++ b/ov/auth_test.go
@@ -22,10 +22,17 @@ func TestSessionLogin(t *testing.T) {
 			t.Fatalf("Failed to execute getTestDriver() ")
 		}
 		data, err := c.SessionLogin()
-		// fmt.Printf("after SessionLogin: %s -> (err) %s", data.ID, err)
+		log.Debugf("after SessionLogin: %s -> (err) %s", data.ID, err)
+
 		assert.NoError(t, err, "SessionLogin threw error -> %s", err)
 		assert.NotEmpty(t, data.ID, fmt.Sprintf("SessionLogin is empty! something went wrong, err -> %s, data -> %+v\n", err, data))
 		assert.Equal(t, "none", c.APIKey)
+
+		c.APIKey = data.ID
+		err = c.SessionLogout()
+		assert.NoError(t, err, "SessionLogout threw error -> %s", err)
+		data, err = c.SessionLogin()
+		assert.NoError(t, err, "SessionLogin threw error -> %s", err)
 	} else {
 		_, c = getTestDriverU()
 		data, err := c.SessionLogin()


### PR DESCRIPTION
Signed-off-by: Edward Raigosa edward.raigosa@hpe.com
