### PR TITLE
Add new option to find public interface by net name

### DIFF
--- a/icsp/icsp_test.go
+++ b/icsp/icsp_test.go
@@ -164,7 +164,8 @@ func TestPreApplyDeploymentJobs(t *testing.T) {
 		log.Infof("server state -> %+v", s.State)
 		assert.True(t, OsdSateMaintenance.Equal(s.State), "server should be in maintenance mode")
 
-		err = c.PreApplyDeploymentJobs(s, 1) // responsible for configuring the Pulbic IP CustomAttributes
+		pubinet, err := s.GetInterface(1)
+		err = c.PreApplyDeploymentJobs(s, pubinet) // responsible for configuring the Pulbic IP CustomAttributes
 		assert.NoError(t, err, "ApplyDeploymentJobs threw error -> %+v, %+v", err, s)
 
 		// verify that the server attribute was saved by getting the server again and checking the value

--- a/icsp/servers.go
+++ b/icsp/servers.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package icsp -
+// Package icsp
 package icsp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -42,6 +43,8 @@ type StorageDevice struct {
 // osdState status
 type osdState int
 
+// OK - The target server is running a production OS with a production version of the agent and is reachable;
+// UNREACHABLE - The managed Server is unreachable by the appliance;
 // MAINTENANCE - The Server has been booted to maintenance, and a maintenance version of the agent has been registered with the appliance.;
 
 const (
@@ -65,7 +68,7 @@ func (o osdState) String() string { return statelist[o] }
 // Equal helper for state
 func (o osdState) Equal(s string) bool { return (strings.ToUpper(s) == strings.ToUpper(o.String())) }
 
-// stage const
+// Stage stage const
 type Stage int
 
 const (
@@ -270,8 +273,32 @@ func (s Server) GetInterfaces() (interfaces []Interface) {
 	return interfaces
 }
 
+// GetInterface get the interface from slot location
+func (s Server) GetInterface(slotid int) (Interface, error) {
+	var interfac Interface
+	inets := s.GetInterfaces()
+	for i, inet := range inets {
+		if i == slotid {
+			return inet, nil
+		}
+	}
+	return interfac, errors.New("Error interface slotid not found please try another interface id.")
+}
+
+// GetInterfaceFromMac get the server interface for mac address
+func (s Server) GetInterfaceFromMac(mac string) (Interface, error) {
+	var intface Interface
+	for _, ife := range s.Interfaces {
+		if strings.ToLower(ife.MACAddr) == strings.ToLower(mac) {
+			intface = ife
+			return intface, nil
+		}
+	}
+	return intface, errors.New("Error interface not found, please try a different mac address.")
+}
+
 // GetPublicIPV4 returns the public ip interface
-// usually called after an os build plan is applied
+//                 usually called after an os build plan is applied
 func (s Server) GetPublicIPV4() (string, error) {
 	var position int
 	position, inetItem := s.GetValueItem("public_ip", "server")

--- a/icsp/servers_test.go
+++ b/icsp/servers_test.go
@@ -38,6 +38,51 @@ func TestGetPublicIPV4(t *testing.T) {
 	}
 }
 
+// TestGetInterfaceFromMac verify that getting an inerface with mac address works
+func TestGetInterfaceFromMac(t *testing.T) {
+	var (
+		d *ICSPTest
+		c *ICSPClient
+		s Server
+	)
+	if os.Getenv("ICSP_TEST_ACCEPTANCE") == "true" {
+		log.Debug("implements acceptance test for TestGetInterfaceFromMac")
+		d, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		serialNumber := d.Tc.GetTestData(d.Env, "FreeBladeSerialNumber").(string)
+		macAddr := d.Tc.GetTestData(d.Env, "FreeMacAddr").(string)
+
+		s, err := c.GetServerBySerialNumber(serialNumber)
+		assert.NoError(t, err, "GetServerBySerialNumber threw error -> %s, %+v\n", err, serialNumber)
+
+		data, err := s.GetInterfaceFromMac(macAddr)
+		assert.NoError(t, err, "GetInterfaceFromMac threw error -> %s, %+v\n", err, data)
+		assert.Equal(t, macAddr, data.MACAddr, "Failed to get interface -> %+v", data)
+		log.Infof("Found interface -> %+v", data)
+	} else {
+		log.Debug("implements unit test for TestGetInterfaces")
+		d, c = getTestDriverU()
+		jsonServerData := d.Tc.GetTestData(d.Env, "ServerJSONString").(string)
+		log.Debugf("jsonServerData => %s", jsonServerData)
+		err := json.Unmarshal([]byte(jsonServerData), &s)
+		assert.NoError(t, err, "Unmarshal Server threw error -> %s, %+v\n", err, jsonServerData)
+
+		log.Debugf("server -> %v", s)
+
+		data := s.GetInterfaces()
+		log.Debugf("Interfaces -> %+v", data)
+		assert.True(t, len(data) > 0, "Failed to get a valid list of interfaces -> %+v", data)
+		for _, inet := range data {
+			log.Debugf("inet -> %+v", inet)
+			log.Debugf("inet ip -> %+v", inet.IPV4Addr)
+			log.Debugf("inet ip -> %+v", inet.Slot)
+			log.Infof("inet ip -> %+v", inet.MACAddr)
+		}
+	}
+}
+
 // TestGetInterfaces  verify that interfaces works
 func TestGetInterfaces(t *testing.T) {
 
@@ -82,6 +127,47 @@ func TestGetInterfaces(t *testing.T) {
 			log.Debugf("inet ip -> %+v", inet.Slot)
 			log.Debugf("inet ip -> %+v", inet.MACAddr)
 		}
+	}
+}
+
+// TestGetInterface implements getting the name of an interface
+func TestGetInterface(t *testing.T) {
+	var (
+		d *ICSPTest
+		c *ICSPClient
+		s Server
+	)
+	if os.Getenv("ICSP_TEST_ACCEPTANCE") == "true" {
+		log.Debug("implements acceptance test for TestGetInterfaceName")
+		d, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		serialNumber := d.Tc.GetTestData(d.Env, "FreeBladeSerialNumber").(string)
+		s, err := c.GetServerBySerialNumber(serialNumber)
+
+		data, err := s.GetInterface(0)
+		assert.NoError(t, err, "GetInterface threw error -> %s, %+v\n", err, data)
+		assert.True(t, len(data.Slot) > 0, "Failed to get a an interface name -> %+v", data)
+		log.Infof("Interface name -> %+v", data.Slot)
+
+		data, err = s.GetInterface(1)
+		assert.NoError(t, err, "GetInterface threw error -> %s, %+v\n", err, data)
+		assert.True(t, len(data.Slot) > 0, "Failed to get a an interface name -> %+v", data)
+		log.Infof("Interface name -> %+v", data.Slot)
+	} else {
+		log.Debug("implements unit test for TestGetInterfaceName")
+		d, c = getTestDriverU()
+		jsonServerData := d.Tc.GetTestData(d.Env, "ServerJSONString").(string)
+		log.Debugf("jsonServerData => %s", jsonServerData)
+		err := json.Unmarshal([]byte(jsonServerData), &s)
+		assert.NoError(t, err, "Unmarshal Server threw error -> %s, %+v\n", err, jsonServerData)
+
+		log.Debugf("server -> %v", s)
+
+		data, err := s.GetInterface(0)
+		log.Infof("Interface Name -> %+v", data)
+		assert.True(t, len(data.Slot) > 0, "Failed to get a valid list of interfaces -> %+v", data)
 	}
 }
 
@@ -223,6 +309,7 @@ func TestDeleteServer(t *testing.T) {
 	}
 }
 
+// TestIsServerManaged test if server is managed
 func TestIsServerManaged(t *testing.T) {
 	var (
 		d *ICSPTest
@@ -241,6 +328,7 @@ func TestIsServerManaged(t *testing.T) {
 	}
 }
 
+// TestGetServerByID test getting a server from id
 func TestGetServerByID(t *testing.T) {
 	var (
 		//d *ICSPTest

--- a/ov/profiles.go
+++ b/ov/profiles.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package ov -
+// Package ov
 package ov
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/HewlettPackard/oneview-golang/rest"
@@ -26,7 +27,7 @@ import (
 	"github.com/docker/machine/libmachine/log"
 )
 
-// firmware
+// FirmwareOption structure for firware settings
 type FirmwareOption struct {
 	FirmwareOptionv200
 	ForceInstallFirmware bool          `json:"forceInstallFirmware,omitempty"` // "forceInstallFirmware": false,
@@ -34,20 +35,20 @@ type FirmwareOption struct {
 	ManageFirmware       bool          `json:"manageFirmware,omitempty"`       // "manageFirmware": false
 }
 
-// Boot mode option
+// BootModeOption mode option
 type BootModeOption struct {
 	ManageMode    bool          `json:"manageMode,omitempty"`    // "manageMode": true,
 	Mode          string        `json:"mode,omitempty"`          // "mode": "BIOS",
 	PXEBootPolicy utils.Nstring `json:"pxeBootPolicy,omitempty"` // "pxeBootPolicy": null
 }
 
-// Boot management
+// BootManagement management
 type BootManagement struct {
 	ManageBoot bool     `json:"manageBoot,omitempty"` // "manageBoot": true,
 	Order      []string `json:"order,omitempty"`      // "order": ["CD","USB","HardDisk","PXE"]
 }
 
-// Bios Settings
+// BiosSettings structure
 type BiosSettings struct {
 	ID    string `json:"id,omitempty"`    // id
 	Value string `json:"value,omitempty"` // value
@@ -94,6 +95,17 @@ type ServerProfile struct {
 	URI                   utils.Nstring       `json:"uri,omitempty"`                   // "uri": "/rest/server-profiles/9979b3a4-646a-4c3e-bca6-80ca0b403a93",
 	UUID                  utils.Nstring       `json:"uuid,omitempty"`                  // "uuid": "30373237-3132-4D32-3235-303930524D57",
 	WWNType               string              `json:"wwnType,omitempty"`               // "wwnType": "Physical",
+}
+
+// GetConnectionByName gets the connection from a profile with a given name
+func (s ServerProfile) GetConnectionByName(name string) (Connection, error) {
+	var connection Connection
+	for _, c := range s.Connections {
+		if c.Name == name {
+			return c, nil
+		}
+	}
+	return connection, errors.New("Error connection not found on server profile, please try a different connection name.")
 }
 
 // Clone server profile

--- a/ov/profiles_test.go
+++ b/ov/profiles_test.go
@@ -101,6 +101,35 @@ func TestGetProfileByName(t *testing.T) {
 	}
 }
 
+// TestGetProfileConnectionByName verify functionality
+func TestGetConnectionByName(t *testing.T) {
+	var (
+		d        *OVTest
+		c        *OVClient
+		testname string
+	)
+	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") == "true" {
+		d, c = getTestDriverA()
+		testname = d.Tc.GetTestData(d.Env, "ServerProfileName").(string)
+		pubcname := d.Tc.GetTestData(d.Env, "FreePublicConnection").(string)
+		expectsmac := d.Tc.GetExpectsData(d.Env, "MACAddress").(string)
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		profile, err := c.GetProfileByName(testname)
+		assert.NoError(t, err, "GetProfileByName threw error -> %s", err)
+
+		for _, c := range profile.Connections {
+			log.Debugf("connection -> %d %s %s %s", c.ID, c.Name, c.MAC, c.MacType)
+		}
+
+		connection, err := profile.GetConnectionByName(pubcname)
+		log.Debugf("Got connection -> %+v", connection)
+		assert.NoError(t, err, "GetConnectionByName threw error -> %s", err)
+		assert.Equal(t, expectsmac, connection.MAC.String(), "GetConnectionByName failed to get connection %+v", err, connection)
+	}
+}
+
 // TestGetProfileNameBySN
 // Acceptance test ->
 // /rest/server-profiles

--- a/test/data/config_EGSL_houston200.json
+++ b/test/data/config_EGSL_houston200.json
@@ -33,8 +33,10 @@
       "enabled": true,
       "test_data": {
         "HostName": "docker_machine_test01",
+        "FreePublicConnection" : "Prod_172",
         "FreeICSPSerialNumber" : "VCGHJL900C",
-        "FreeBladeSerialNumber" : "2M25090RMS",
+        "FreeBladeSerialNumber" : "VCGADVT00T",
+        "FreeMacAddr": "A6:3B:44:70:00:66",
         "FreeBladeName" : "HOUEGSL-C7000-04, bay 5",
         "FreeHostName": "houegsl-c7000-04-ilo05",
         "IcspName" : "IC04-HOUEGSL-C7000-04-5",
@@ -51,7 +53,7 @@
       },
       "expects_data": {
         "IloIPAddress":  "16.85.0.34",
-        "MACAddress": "D6:6D:EC:10:00:22",
+        "MACAddress": "D6:6D:EC:10:00:E7",
         "CurrentVersion": 200,
         "MinimumVersion": 1,
         "FakeData": "foo",


### PR DESCRIPTION
```
- Adds new method GetInterfaceFromMac for server in icsp
- Adds new method GetConnectionByName for server profile in ov
- Adds a new option --oneview-public-connection-name that overrides slotid
```

Signed-off-by: Edward Raigosa edward.raigosa@hpe.com
