### PR TITLE
fix buid plan hanging with --debug

### DIFF
--- a/icsp/build_plan.go
+++ b/icsp/build_plan.go
@@ -93,7 +93,8 @@ func (c *ICSPClient) GetAllBuildPlans() (OSBuildPlan, error) {
 		return plans, err
 	}
 
-	log.Debugf("GetAllBuildPlans %s", data)
+	// log.Debugf("GetAllBuildPlans %s", data)
+	log.Debugf("GetAllBuildPlans completed")
 	if err := json.Unmarshal([]byte(data), &plans); err != nil {
 		return plans, err
 	}

--- a/testconfig/testconfig.go
+++ b/testconfig/testconfig.go
@@ -55,6 +55,9 @@ func (tc *TestConfig) GetTestingConfiguration(config_name string) {
 		Pkg           PackageInfo
 		test_data_dir string
 	)
+	if os.Getenv("ONEVIEW_DEBUG") == "true" {
+		log.IsDebug = true
+	}
 	package_root = os.Getenv("TESTCONFIG_PACKAGE_ROOT_PATH")
 	if found, package_full_dir := Pkg.GetPackageRootDir(package_root); found == true {
 		test_data_dir = Pkg.JoinPath([]string{package_full_dir,


### PR DESCRIPTION
When we look for os build plans, we could run into hanging the docker-machine
driver with using --debug.  This removes the debuging log output for
data returned on the call for get build plans.

We've also added an option to control debug output in our test cases
for the logger

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>