### PR TITLE
Fix how we get ipv4 for (#48)

### DIFF
--- a/icsp/icsp_test.go
+++ b/icsp/icsp_test.go
@@ -178,7 +178,7 @@ func TestPreApplyDeploymentJobs(t *testing.T) {
 		assert.NoError(t, err, "GetInterface(1) threw error -> %s, %+v\n", err, s)
 		assert.Equal(t, macAddr, pubinet.MACAddr, fmt.Sprintf("should get a valid interface -> %+v", pubinet))
 
-		err = c.PreApplyDeploymentJobs(s, pubinet) // responsible for configuring the Pulbic IP CustomAttributes
+		s, err = c.PreApplyDeploymentJobs(s, pubinet) // responsible for configuring the Pulbic IP CustomAttributes
 		assert.NoError(t, err, "ApplyDeploymentJobs threw error -> %+v, %+v", err, s)
 		s, err = s.ReloadFull(c)
 		assert.NoError(t, err, "ReloadFull threw error -> %+v, %+v", err, s)

--- a/icsp/server_customattribute.go
+++ b/icsp/server_customattribute.go
@@ -59,11 +59,11 @@ func (s *Server) GetValueItems(key string) (int, []ValueItem) {
 // SetValueItems object
 func (s *Server) SetValueItems(key string, newv ValueItem) {
 	_, oldv := s.GetValueItem(key, newv.Scope)
-	log.Debugf("ValueItem => %+v", oldv)
+	log.Debugf("GetValueItem(%s, %s)=> %+v", key, newv.Scope, oldv)
 
 	if i, oldv := s.GetValueItem(key, newv.Scope); i < 0 {
 		// creat a new ValueItem
-		log.Debugf("Adding new ValueItem => %v+", newv)
+		log.Debugf("Adding new GetValueItem(%s, %s) => %+v", key, newv.Scope, newv)
 		vi, _ := s.GetValueItems(key)
 		if vi < 0 {
 			// a new key is needed
@@ -73,7 +73,7 @@ func (s *Server) SetValueItems(key string, newv ValueItem) {
 		}
 	} else {
 		// set an existing one
-		log.Debugf("Change %v+ to >>  %v+", oldv, newv)
+		log.Debugf("Change(%s) %+v to >>  %+v", key, oldv, newv)
 		vi, _ := s.GetValueItems(key)
 		s.CustomAttributes[vi].Values[i] = ValueItem{Scope: newv.Scope, Value: newv.Value}
 	}

--- a/icsp/servers.go
+++ b/icsp/servers.go
@@ -303,9 +303,12 @@ func (s Server) GetPublicIPV4() (string, error) {
 	position, inetItem := s.GetValueItem("public_ip", "server")
 	if position >= 0 {
 		log.Debugf("getting ip from public_ip -> %+v", inetItem.Value)
-		return inetItem.Value, nil
+		if inetItem.Value != "" {
+			return inetItem.Value, nil
+		}
 	}
 
+	log.Debugf("GetPublicIPV4 from GetPublicInterface()")
 	inet, err := s.GetPublicInterface()
 	if err != nil {
 		return "", err
@@ -324,11 +327,13 @@ func (s Server) GetPublicInterface() (*Interface, error) {
 	position, inetItem := s.GetValueItem("public_interface", "server")
 	if position >= 0 {
 		inetJSON := inetItem.Value
+		log.Debugf("GetPublicInterface -> %s", inetJSON)
 		if len(inetJSON) > 0 {
 			err = json.Unmarshal([]byte(inetJSON), &inet)
+			return inet, err
 		}
 	}
-	return inet, err
+	return inet, errors.New("Error public_interface custom attribute is not found.")
 }
 
 // ReloadFull GetServers() only returns a partial object, reload it to get everything


### PR DESCRIPTION
We needed to fix how we get ipv4 from public_ip
so that we don't get an empty value, and move on to check
public_interface value.   public_ip should be used for
dns alias and such.

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>