### PR TITLE
Fix for #40: implement ideltimeout checks

### DIFF
--- a/icsp/auth.go
+++ b/icsp/auth.go
@@ -60,6 +60,11 @@ type Auth struct {
 	Domain   string `json:"authLoginDomain,omitempty"`
 }
 
+// TimeOut structure
+type TimeOut struct {
+	IdleTimeout int64 `json:"idleTimeout"`
+}
+
 // RefreshLogin Refresh login authkey
 // Should make sure we have a valid APIKey
 func (c *ICSPClient) RefreshLogin() error {
@@ -71,7 +76,15 @@ func (c *ICSPClient) RefreshLogin() error {
 		}
 		c.APIKey = s.ID
 	}
-	// TODO: validate that session id is valid, if not refresh it
+	// check it we are getting 404 Not Found from GetIdleTimeout, this means the Session-ID is no good
+	_, err := c.GetIdleTimeout()
+	if err != nil && strings.Contains(err.Error(), "404 Not Found") {
+		s, err := c.SessionLogin()
+		if err != nil {
+			return err
+		}
+		c.APIKey = s.ID
+	}
 	return nil
 }
 
@@ -115,5 +128,47 @@ func (c *ICSPClient) SessionLogout() error {
 		return err
 	}
 	c.APIKey = "none"
+	return nil
+}
+
+// GetIdleTimeout gets the current timeout for the logged on session
+// returns timeout in milliseconds, or error when it fails
+func (c *ICSPClient) GetIdleTimeout() (int64, error) {
+	var (
+		uri     = "/rest/sessions/idle-timeout"
+		timeout TimeOut
+		header  map[string]string
+	)
+	log.Debugf("Calling idel-timeout get for header -> %+v", c.GetAuthHeaderMap())
+	header = c.GetAuthHeaderMap()
+	header["Session-ID"] = header["auth"]
+	c.SetAuthHeaderOptions(header)
+	data, err := c.RestAPICall(rest.GET, uri, nil)
+	if err != nil {
+		return -1, err
+	}
+	log.Debugf("Timeout data %s", data)
+	if err := json.Unmarshal([]byte(data), &timeout); err != nil {
+		return -1, err
+	}
+	return timeout.IdleTimeout, nil
+}
+
+// SetIdleTimeout sets the current timeout
+func (c *ICSPClient) SetIdleTimeout(thetime int64) error {
+	var (
+		uri     = "/rest/sessions/idle-timeout"
+		timeout TimeOut
+		header  map[string]string
+	)
+	timeout.IdleTimeout = thetime
+	log.Debugf("Calling idel-timeout POST for header -> %+v", c.GetAuthHeaderMap())
+	header = c.GetAuthHeaderMap()
+	header["Session-ID"] = header["auth"]
+	c.SetAuthHeaderOptions(header)
+	_, err := c.RestAPICall(rest.POST, uri, timeout)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/icsp/auth_test.go
+++ b/icsp/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/docker/machine/libmachine/log"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,90 @@ func TestSessionLogin(t *testing.T) {
 	}
 }
 
+// Get the current idle timeout from the logged in session
+func TestGetIdleTimeout(t *testing.T) {
+	var (
+		c *ICSPClient
+		// d *ICSPTest
+	)
+	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") == "true" {
+		_, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		err := c.RefreshLogin()
+		log.Debugf(" login key -> %s", c.APIKey)
+		assert.NoError(t, err, "RefreshLogin threw error -> %s", err)
+
+		timeout, err := c.GetIdleTimeout()
+		assert.NoError(t, err, "GetIdleTimeout threw error -> %s", err)
+		log.Debugf(" idle timeout -> %d", timeout)
+	}
+
+}
+
+// Set idle timeout
+func TestSetIdleTimeout(t *testing.T) {
+	var (
+		c *ICSPClient
+		// d *ICSPTest
+		testtime int64
+	)
+	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") == "true" {
+		testtime = 25000
+		_, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		err := c.RefreshLogin()
+		log.Debugf(" login key -> %s", c.APIKey)
+		assert.NoError(t, err, "RefreshLogin threw error -> %s", err)
+
+		err = c.SetIdleTimeout(testtime)
+		assert.NoError(t, err, "SetIdleTimeout threw error -> %s", err)
+
+		timeout, err := c.GetIdleTimeout()
+		assert.NoError(t, err, "GetIdleTimeout threw error -> %s", err)
+		assert.Equal(t, testtime, timeout, "Should get timeout equal, %s", timeout)
+		log.Debugf(" idle timeout -> %d", timeout)
+	}
+
+}
+
+// Test for expired key and see if RefreshLogin can restore the key if we have a bad key
+func TestSessionExpiredKey(t *testing.T) {
+	var (
+		c *ICSPClient
+		d *ICSPTest
+	)
+	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") == "true" {
+		d, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		err := c.RefreshLogin()
+		log.Debugf(" login key -> %s", c.APIKey)
+		assert.NoError(t, err, "RefreshLogin threw error -> %s", err)
+		// force key to timeout
+		err = c.SetIdleTimeout(800)
+		assert.NoError(t, err, "SetIdleTimeout threw error -> %s", err)
+
+		// 1 millisecond and we should be timeout with the current key
+		time.Sleep(1 * time.Millisecond)
+
+		// verify we are timed out
+		_, err = c.GetIdleTimeout()
+		assert.Error(t, err, "should be 404 not found -> %s ", err)
+
+		// verify that we can access something from icps with this client
+		// This should not fail because it uses RefreshLogin to get a new login session and avoid timeout
+		serialNumber := d.Tc.GetTestData(d.Env, "SerialNumber").(string)
+		s, err := c.GetServerBySerialNumber(serialNumber)
+		assert.NoError(t, err, "GetServerBySerialNumber threw error -> %s, server -> %+v", err, s)
+	}
+
+}
+
 // Test SessionLogout
 func TestSessionLogout(t *testing.T) {
 	var (
@@ -59,6 +144,7 @@ func TestSessionLogout(t *testing.T) {
 		//assert.NotEmpty(t, data.ID, fmt.Sprintf("SessionLogin is empty! something went wrong, err -> %s, data -> %+v\n", err, data))
 		//assert.Equal(t, "none", c.APIKey)
 		err = c.SessionLogout()
+		log.Debugf(" login key after logout -> %s", c.APIKey)
 		assert.NoError(t, err, "SessionLogout threw error -> %s", err)
 		// test if we can perform an op after logout
 		//_, err = c.GetProfileBySN(testSerial)


### PR DESCRIPTION
This gives refreshlogin in icsp api's the ability
to detect when we have a timedout token, and
refreshes it so we can continue without issues.

Signed-off-by: Edward Raigosa <edward.raigosa@hp.com>