### PR TITLE
fix #40: ov session expires cause api execution failure

### DIFF
--- a/ov/auth_test.go
+++ b/ov/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/docker/machine/libmachine/log"
 	"github.com/stretchr/testify/assert"
@@ -73,4 +74,89 @@ func TestSessionLogout(t *testing.T) {
 		assert.Equal(t, "none", c.APIKey)
 		*/
 	}
+}
+
+// Get the current idle timeout from the logged in session
+func TestGetIdleTimeout(t *testing.T) {
+	var (
+		c *OVClient
+		// d *OVTest
+	)
+	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") == "true" {
+		_, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		err := c.RefreshLogin()
+		log.Debugf(" login key -> %s", c.APIKey)
+		assert.NoError(t, err, "RefreshLogin threw error -> %s", err)
+
+		timeout, err := c.GetIdleTimeout()
+		assert.NoError(t, err, "GetIdleTimeout threw error -> %s", err)
+		log.Debugf(" idle timeout -> %d", timeout)
+	}
+
+}
+
+// Set idle timeout
+func TestSetIdleTimeout(t *testing.T) {
+	var (
+		c        *OVClient
+		testtime int64
+	)
+	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") == "true" {
+		testtime = 25000
+		_, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		err := c.RefreshLogin()
+		log.Debugf(" login key -> %s", c.APIKey)
+		assert.NoError(t, err, "RefreshLogin threw error -> %s", err)
+
+		err = c.SetIdleTimeout(testtime)
+		assert.NoError(t, err, "SetIdleTimeout threw error -> %s", err)
+
+		timeout, err := c.GetIdleTimeout()
+		assert.NoError(t, err, "GetIdleTimeout threw error -> %s", err)
+		assert.Equal(t, testtime, timeout, "Should get timeout equal, %s", timeout)
+		log.Debugf(" idle timeout -> %d", timeout)
+	}
+
+}
+
+// Test for expired key and see if RefreshLogin can restore the key if we have a bad key
+func TestSessionExpiredKey(t *testing.T) {
+	var (
+		c *OVClient
+		d *OVTest
+	)
+	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") == "true" {
+		d, c = getTestDriverA()
+		if c == nil {
+			t.Fatalf("Failed to execute getTestDriver() ")
+		}
+		err := c.RefreshLogin()
+		log.Debugf(" login key -> %s", c.APIKey)
+		assert.NoError(t, err, "RefreshLogin threw error -> %s", err)
+		// force key to timeout
+		err = c.SetIdleTimeout(800)
+		assert.NoError(t, err, "SetIdleTimeout threw error -> %s", err)
+
+		// 1 millisecond and we should be timeout with the current key
+		time.Sleep(1 * time.Millisecond)
+
+		// verify we are timed out
+		_, err = c.GetIdleTimeout()
+		assert.Error(t, err, "should be 404 not found -> %s ", err)
+
+		// verify that we can access something from icps with this client
+		// This should not fail because it uses RefreshLogin to get a new login session and avoid timeout
+		profileName := d.Tc.GetTestData(d.Env, "ServerProfileName").(string)
+		data, err := c.GetProfileByName(profileName)
+		assert.NoError(t, err, "GetProfileByName threw error -> %s", err)
+		assert.Equal(t, profileName, data.Name)
+
+	}
+
 }


### PR DESCRIPTION
We need to have a way to detect when the idle time for a session
is now expired, and renew it when it has

Signed-off-by: Edward Raigosa <edward.raigosa@hp.com>