### PR TITLE
Fix #67: san storage options need to be visible even when not set

### DIFF
--- a/ov/storage.go
+++ b/ov/storage.go
@@ -23,16 +23,16 @@ import (
 
 // LogicalDrive logical drive options
 type LogicalDrive struct {
-	Bootable  bool   `json:"bootable,omitempty"`  // "bootable": true,
+	Bootable  bool   `json:"bootable"`            // "bootable": true,
 	RaidLevel string `json:"raidLevel,omitempty"` // "raidLevel": "RAID1"
 }
 
 // LocalStorageOptions -
 type LocalStorageOptions struct { // "localStorage": {
 	LocalStorageSettingsV3
-	ManageLocalStorage bool           `json:"manageLocalStorage,omitempty"` // "manageLocalStorage": true,
-	LogicalDrives      []LogicalDrive `json:"logicalDrives,omitempty"`      // "logicalDrives": [],
-	Initialize         bool           `json:"initialize,omitempty"`         // 				"initialize": true
+	ManageLocalStorage bool           `json:"manageLocalStorage"`      // "manageLocalStorage": true,
+	LogicalDrives      []LogicalDrive `json:"logicalDrives,omitempty"` // "logicalDrives": [],
+	Initialize         bool           `json:"initialize"`              // 				"initialize": true
 } // 		},
 
 // Clone local storage
@@ -49,7 +49,7 @@ func (c LocalStorageOptions) Clone() LocalStorageOptions {
 //to retrieve the storage targets for the associated network.
 type StoragePath struct {
 	ConnectionID      int      `json:"connectionId,omitempty"`      // connectionId (required), The ID of the connection associated with this storage path. Use GET /rest/server-profiles/available-networks to retrieve the list of available networks.
-	IsEnabled         bool     `json:"isEnabled,omitempty"`         // isEnabled (required), Identifies whether the storage path is enabled.
+	IsEnabled         bool     `json:"isEnabled"`                   // isEnabled (required), Identifies whether the storage path is enabled.
 	Status            string   `json:"status,omitempty"`            // status (read only), The overall health status of the storage path.
 	StorageTargetType string   `json:"storageTargetType,omitempty"` // storageTargetType ('Auto', 'TargetPorts')
 	StorageTargets    []string `json:"storageTargets,omitempty"`    // only set when storageTargetType is TargetPorts
@@ -70,7 +70,7 @@ type VolumeAttachment struct {
 	ID                             int           `json:"id,omitempty"`                             // id, The ID of the attached storage volume.
 	LUN                            string        `json:"lun,omitempty"`                            // lun, The logical unit number.
 	LUNType                        string        `json:"lunType,omitempty"`                        // lunType(required), The logical unit number type: Auto or Manual.
-	Permanent                      bool          `json:"permanent,omitempty"`                      // permanent, If true, indicates that the volume will persist when the profile is deleted. If false, then the volume will be deleted when the profile is deleted.
+	Permanent                      bool          `json:"permanent"`                                // permanent, If true, indicates that the volume will persist when the profile is deleted. If false, then the volume will be deleted when the profile is deleted.
 	State                          string        `json:"state,omitempty"`                          // state(read only), current state of the attachment
 	Status                         string        `json:"status,omitempty"`                         // status(read only), The current status of the attachment.
 	StoragePaths                   []StoragePath `json:"storagePaths,omitempty"`                   // A list of host-to-target path associations.
@@ -78,7 +78,7 @@ type VolumeAttachment struct {
 	VolumeName                     string        `json:"volumeName,omitempty"`                     // The name of the volume. This attribute is required when creating a volume.
 	VolumeProvisionType            string        `json:"volumeProvisionType,omitempty"`            // The provisioning type of the new volume: Thin or Thick. This attribute is required when creating a volume.
 	VolumeProvisionedCapacityBytes string        `json:"volumeProvisionedCapacityBytes,omitempty"` // The requested provisioned capacity of the storage volume in bytes. This attribute is required when creating a volume.
-	VolumeShareable                bool          `json:"volumeShareable,omitempty"`                // Identifies whether the storage volume is shared or private. If false, then the volume will be private. If true, then the volume will be shared. This attribute is required when creating a volume.
+	VolumeShareable                bool          `json:"volumeShareable"`                          // Identifies whether the storage volume is shared or private. If false, then the volume will be private. If true, then the volume will be shared. This attribute is required when creating a volume.
 	VolumeStoragePoolURI           utils.Nstring `json:"volumeStoragePoolUri,omitempty"`           // The URI of the storage pool associated with this volume attachment's volume. Use GET /rest/server-profiles/available-storage-systems to retrieve the URI of the storage pool associated with a volume.
 	VolumeStorageSystemURI         utils.Nstring `json:"volumeStorageSystemUri,omitempty"`         // The URI of the storage system associated with this volume attachment. Use GET /rest/server-profiles/available-storage-systems to retrieve the URI of the storage system associated with a volume.
 	VolumeURI                      utils.Nstring `json:"volumenUri,omitempty"`                     // The URI of the storage volume associated with this volume attachment. Use GET /rest/server-profiles/available-storage-systems to retrieve the URIs of available storage volumes.
@@ -116,7 +116,7 @@ func (c VolumeAttachment) Clone() VolumeAttachment {
 type SanStorageOptions struct { // sanStorage
 	SanStorageV3
 	HostOSType            string             `json:"hostOSType,omitempty"`            // hostOSType(required),  The operating system type of the host. To retrieve the list of supported host OS types, issue a REST Get request using the /rest/storage-systems/host-types API.
-	ManageSanStorage      bool               `json:"manageSanStorage,omitempty"`      // manageSanStorage(required),  Identifies whether SAN storage is managed in this profile.
+	ManageSanStorage      bool               `json:"manageSanStorage"`                // manageSanStorage(required),  Identifies whether SAN storage is managed in this profile.
 	VolumeAttachments     []VolumeAttachment `json:"volumeAttachments,omitempty"`     // volumeAttachments, The list of storage volume attachments. array of Volume Attachment
 	SerialNumber          string             `json:"serialNumber,omitempty"`          // serialNumber (searchable) A 10-byte value that is exposed to the Operating System as the server hardware's Serial Number. The value can be a virtual serial number, user defined serial number or physical serial number read from the server's ROM. It cannot be modified after the profile is created.
 	SerialNumberType      string             `json:"serialNumberType,omitempty"`      // serialNumberType (searchable) Specifies the type of Serial Number and UUID to be programmed into the server ROM. The value can be 'Virtual', 'UserDefined', or 'Physical'. The serialNumberType defaults to 'Virtual' when serialNumber or uuid are not specified. It cannot be modified after the profile is created.

--- a/ov/storagev2.go
+++ b/ov/storagev2.go
@@ -30,17 +30,17 @@ type LocalStorageSettingsV3 struct { // "localStorage": {
 
 // LocalStorageEmbeddedController -
 type LocalStorageEmbeddedController struct {
-	ImportConfiguration bool             `json:"importConfiguration,omitempty"` // importConfiguration Determines if the logical drives in the current configuration should be imported. Boolean
-	Initialize          bool             `json:"initialize,omitempty"`          // initialize Determines if the controller should be initialized before configuration. Boolean
-	LogicalDrives       []LogicalDriveV3 `json:"logicalDrives,omitempty"`       // LogicalDriveV3 The list of logical drives associated with the controller.
-	Managed             bool             `json:"managed,omitempty"`             // managed Determines if the specific controller is managed by OneView. Boolean
-	Mode                string           `json:"mode,omitempty"`                // mode Determines the mode of operation of the controller. The controller mode can be changed between RAID and HBA mode when supported by the selected server hardware type. string
-	SlotNumber          string           `json:"slotNumber,omitempty"`          // slotNumber The PCI slot number used by the controller. This value will always be set to "0", as only the embedded controller is supported in the current version. string
+	ImportConfiguration bool             `json:"importConfiguration"`     // importConfiguration Determines if the logical drives in the current configuration should be imported. Boolean
+	Initialize          bool             `json:"initialize"`              // initialize Determines if the controller should be initialized before configuration. Boolean
+	LogicalDrives       []LogicalDriveV3 `json:"logicalDrives,omitempty"` // LogicalDriveV3 The list of logical drives associated with the controller.
+	Managed             bool             `json:"managed"`                 // managed Determines if the specific controller is managed by OneView. Boolean
+	Mode                string           `json:"mode,omitempty"`          // mode Determines the mode of operation of the controller. The controller mode can be changed between RAID and HBA mode when supported by the selected server hardware type. string
+	SlotNumber          string           `json:"slotNumber,omitempty"`    // slotNumber The PCI slot number used by the controller. This value will always be set to "0", as only the embedded controller is supported in the current version. string
 }
 
 // LogicalDriveV3 -
 type LogicalDriveV3 struct {
-	Bootable          bool   `json:"bootable,omitempty"`          // bootable Indicates if the logical drive is bootable or not. Boolean
+	Bootable          bool   `json:"bootable"`                    // bootable Indicates if the logical drive is bootable or not. Boolean
 	DriveName         string `json:"driveName,omitempty"`         // driveName The name of the logical drive. string
 	DriveNumber       int    `json:"driveNumber,omitempty"`       // driveNumber The number assigned to the logical drive by HP SSA. This value is read-only and gets automatically populated once the logical drive is created. integer read only
 	DriveTechnology   string `json:"driveTechnology,omitempty"`   // driveTechnology Defines the interface type for drives that will be used to build the logical drive. Supported values depend on the local storage capabilities of the selected server hardware type. string
@@ -51,7 +51,7 @@ type LogicalDriveV3 struct {
 // SanStorageV3 -
 type SanStorageV3 struct {
 	HostOSType        string               `json:"hostOSType,omitempty"`        // hostOSType The operating system type of the host. To retrieve the list of supported host OS types, issue a REST Get request using the /rest/storage-systems/host-types API. string required
-	ManageSanStorage  bool                 `json:"manageSanStorage,omitempty"`  // manageSanStorage Identifies whether SAN storage is managed in this profile. Boolean required
+	ManageSanStorage  bool                 `json:"manageSanStorage"`            // manageSanStorage Identifies whether SAN storage is managed in this profile. Boolean required
 	VolumeAttachments []VolumeAttachmentV2 `json:"volumeAttachments,omitempty"` // The list of storage volume attachments.
 }
 
@@ -60,7 +60,7 @@ type VolumeAttachmentV2 struct {
 	ID                             int             `json:"id,omitempty"`                             // id The ID of the attached storage volume. integer
 	LUN                            string          `json:"lun,omitempty"`                            // lun The logical unit number. string
 	LUNType                        string          `json:"lunType,omitempty"`                        // lunType The logical unit number type: Auto or Manual. string required
-	Permanent                      bool            `json:"permanent,omitempty"`                      // permanent If true, indicates that the volume will persist when the profile is deleted. If false, then the volume will be deleted when the profile is deleted. Boolean
+	Permanent                      bool            `json:"permanent"`                                // permanent If true, indicates that the volume will persist when the profile is deleted. If false, then the volume will be deleted when the profile is deleted. Boolean
 	State                          string          `json:"state,omitempty"`                          //state The current state of the attachment. VolumeAttachmentStateV2 read only
 	Status                         string          `json:"status,omitempty"`                         // status The current status of the attachment. string read only
 	StoragePaths                   []StoragePathV2 `json:"storagePaths,omitempty"`                   // A list of host-to-target path associations.
@@ -68,7 +68,7 @@ type VolumeAttachmentV2 struct {
 	VolumeName                     string          `json:"volumeName,omitempty"`                     // volumeName The name of the volume. This attribute is required when creating a volume. string
 	VolumeProvisionType            string          `json:"volumeProvisionType,omitempty"`            // volumeProvisionType The provisioning type of the new volume: Thin or Thick. This attribute is required when creating a volume. string
 	VolumeProvisionedCapacityBytes string          `json:"volumeProvisionedCapacityBytes,omitempty"` // volumeProvisionedCapacityBytes The requested provisioned capacity of the storage volume in bytes. This attribute is required when creating a volume. string
-	VolumeSahreable                bool            `json:"volumeShareable,omitempty"`                // volumeShareable Identifies whether the storage volume is shared or private. If false, then the volume will be private. If true, then the volume will be shared. This attribute is required when creating a volume. Boolean
+	VolumeShareable                bool            `json:"volumeShareable"`                          // volumeShareable Identifies whether the storage volume is shared or private. If false, then the volume will be private. If true, then the volume will be shared. This attribute is required when creating a volume. Boolean
 	VolumeStoragePoolURI           utils.Nstring   `json:"volumeStoragePoolUri,omitempty"`           // volumeStoragePoolUri The URI of the storage pool associated with this volume attachment's volume. Use GET /rest/server-profiles/available-storage-systems to retrieve the URI of the storage pool associated with a volume. string
 	VolumeStorageSystemURI         utils.Nstring   `json:"volumeStorageSystemUri,omitempty"`         // volumeStorageSystemUri The URI of the storage system associated with this volume attachment. Use GET /rest/server-profiles/available-storage-systems to retrieve the URI of the storage system associated with a volume. string Format URI
 	VolumeURI                      utils.Nstring   `json:"volumeUri,omitempty"`                      // volumeUri The URI of the storage volume associated with this volume attachment. Use GET /rest/server-profiles/available-storage-systems to retrieve the URIs of available storage volumes. string Format URI
@@ -123,7 +123,7 @@ func (o VolumeAttachmentStateV2) Equal(s string) bool {
 // StoragePathV2 - A list of host-to-target path associations.
 type StoragePathV2 struct {
 	ConnectionID      int      `json:"connectionId,omitempty"`      // connectionId The ID of the connection associated with this storage path. Use GET /rest/server-profiles/available-networks to retrieve the list of available networks. integer required
-	IsEnabled         bool     `json:"isEnabled,omitempty"`         // isEnabled Identifies whether the storage path is enabled. Boolean required
+	IsEnabled         bool     `json:"isEnabled"`                   // isEnabled Identifies whether the storage path is enabled. Boolean required
 	Status            string   `json:"status,omitempty"`            // status The overall health status of the storage path. string read only
 	StorageTargetType string   `json:"storageTargetType,omitempty"` // storageTargetType If set to Auto, the storage system will automatically identify the storage targets. In this case, set the storageTargets field to an empty array. If set to TargetPorts, the storage targets can be manually specified in the storageTargets field using comma-separated strings.
 	StorageTargets    []string `json:"storageTargets,omitempty"`    // The WWPNs (World Wide Port Names) of the targets on the storage system. If storageTargetType is set to Auto, the storage system will automatically select the target ports, in which case the storageTargets field is not needed and should be set to an empty array. If storageTargetType is set to TargetPorts, then the the storageTargets field should be an array of comma-separated strings representing the WWPNs intended to be used to connect with the storage system. Use GET /rest/storage-systems/{arrayid}/managedPorts?query="expectedNetworkUri EQ '/rest/fc-networks/{netowrk-id}'" to retrieve the storage targets for the associated network.


### PR DESCRIPTION
- Fix typo with volumeShareable property
- fix all bools to exist even when empty

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>