### PR TITLE
Fix for golang 1.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@
 # we use secrets project for variables, see http://readme.drone.io/build/secrets.html
 #
 build:
-  image: golang:1.5.1
+  image: golang:1.6
   environment:
     - HTTP_PROXY=$$HTTP_PROXY
     - HTTPS_PROXY=$$HTTPS_PROXY

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5.1
+- 1.6
 install:
 - go get github.com/mattn/goveralls
 - go get -u github.com/golang/lint/golint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.3
+FROM golang:1.6
 
 RUN go get  github.com/golang/lint/golint \
             github.com/mattn/goveralls \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test: gen-dockerfile
 		    -e TARGET_ARCH \
 		    -e PREFIX \
 		    -e GO15VENDOREXPERIMENT \
+				-e TEST_RUN \
 		    $(DOCKER_IMAGE_NAME) \
 		    make $@
 

--- a/rest/method_test.go
+++ b/rest/method_test.go
@@ -1,0 +1,16 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMethod(t *testing.T) {
+	var m Method
+	m = GET
+	assert.Equal(t, "GET", m.String(), "GET should be string")
+	assert.Equal(t, "POST", POST.String(), "POST should be string")
+	assert.Equal(t, "PUT", PUT.String(), "PUT should be string")
+	assert.Equal(t, "DELETE", DELETE.String(), "DELETE should be string")
+}

--- a/rest/netutil.go
+++ b/rest/netutil.go
@@ -115,7 +115,7 @@ func (c *Client) RestAPICall(method Method, path string, options interface{}) ([
 	client := &http.Client{Transport: tr}
 
 	log.Debugf("*** url => %s", Url.String())
-	log.Debugf("*** method => %s", string(method))
+	log.Debugf("*** method => %s", method.String())
 
 	// parse url
 	reqUrl, err := url.Parse(Url.String())
@@ -130,9 +130,9 @@ func (c *Client) RestAPICall(method Method, path string, options interface{}) ([
 			return nil, err
 		}
 		log.Debugf("*** options => %+v", bytes.NewBuffer(OptionsJSON))
-		req, err = http.NewRequest(string(method), reqUrl.String(), bytes.NewBuffer(OptionsJSON))
+		req, err = http.NewRequest(method.String(), reqUrl.String(), bytes.NewBuffer(OptionsJSON))
 	} else {
-		req, err = http.NewRequest(string(method), reqUrl.String(), nil)
+		req, err = http.NewRequest(method.String(), reqUrl.String(), nil)
 	}
 
 	if err != nil {
@@ -156,7 +156,7 @@ func (c *Client) RestAPICall(method Method, path string, options interface{}) ([
 	}
 
 	// req.SetBasicAuth(c.User, c.APIKey)
-	req.Method = fmt.Sprintf("%s", method)
+	req.Method = fmt.Sprintf("%s", method.String())
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Update rest method for golang 1.6 so that we specifically use String() method
Update testing to be in 1.6

Signed-off-by: Edward Raigosa <wenlock@hp.com>