### PR TITLE
Fixes #61 local build so that USE_CONTAINER=true is the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # # Plain make targets if not requested inside a container
 
+USE_CONTAINER ?= true
+
 define noop_targets
 	@make -pn | sed -rn '/^[^# \t\.%].*:[^=]?/p'|grep -v '='| grep -v '(%)'| grep -v '/'| awk -F':' '{print $$1}'|sort -u;
 endef
@@ -8,7 +10,7 @@ include Makefile.inc
 
 ifneq (,$(findstring test-integration,$(MAKECMDGOALS)))
 	include mk/main.mk
-else ifeq ($(USE_CONTAINER),)
+else ifeq ($(USE_CONTAINER),false)
 	include mk/main.mk
 else
 # Otherwise, with docker, swallow all targets and forward into a container
@@ -45,7 +47,11 @@ test: gen-dockerfile
 		    -e TARGET_ARCH \
 		    -e PREFIX \
 		    -e GO15VENDOREXPERIMENT \
-				-e TEST_RUN \
+		    -e TEST_RUN \
+		    -e ONEVIEW_DEBUG \
+		    -e GH_USER \
+		    -e GH_REPO \
+		    -e USE_CONTAINER=false \
 		    $(DOCKER_IMAGE_NAME) \
 		    make $@
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,9 +1,8 @@
 # Project name, used to name the binaries
 PKG_NAME := oneview-golang
 # Github infos
-GITHUB_INFO := $(shell git config --get remote.origin.url | sed 's/\.git//g'| sed -e 's/\(.*:\/\/\)\(.*\)/\2/')
-GH_USER ?= $(shell echo $(GITHUB_INFO) | cut -d \/ -f 2)
-GH_REPO ?= $(shell echo $(GITHUB_INFO) | cut -d \/ -f 3)
+GH_USER ?= HewlettPackard
+GH_REPO ?= oneview-golang
 
 # If true, disable optimizations and does NOT strip the binary
 DEBUG ?=

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make test
 
 ### Without docker
 * Install golang 1.5 or better
-* Install go pakcages listed in .travis.yml
+* Install go packages listed in .travis.yml
 ```
 USE_CONTAINER=false make test
 ```

--- a/README.md
+++ b/README.md
@@ -5,18 +5,26 @@
 HPE OneView allows you to treat your physical infrastructure as code, and now
 you can integrate your favorite tools based in golang with HPE OneView.
 
+## Build requirements
+We use docker to build and test, run this project on a system that has docker. 
+If you don't use docker, you will need to install and setup go-lang locally as
+well as any other make requirements.  You can use `USE_CONTAINER=false` environment
+setting for make to avoid using docker. Otherwise make sure to have these tools:
+- docker client and daemon
+- gnu make tools
+
 ## Testing your changes
 
 ### From a container
 ```
-USE_CONTAINER=1 make test
+make test
 ```
 
-### From your local system
+### Without docker
 * Install golang 1.5 or better
 * Install go pakcages listed in .travis.yml
 ```
-make test
+USE_CONTAINER=false make test
 ```
 
 ## Contributing


### PR DESCRIPTION
We'll also have to update the travis.yml build so that USE_CONTAINER=false
but GH_REPO and GH_USER are no longer needed and can be hard coded.

Fixes Issue #61

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>