### PR TITLE
fix issue #94 - issue with v2 detection

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -52,11 +52,29 @@ Output from test case debugging log can be handy.
 ONEVIEW_DEBUG=true make test-acceptance
 ```
 
-Run a single specific test
+Run a single specific test with docker
 ---------------------------
 Sometimes it's usefull to run just a single test case.
 ```bash
-ONEVIEW_DEBUG=true make test-acceptance TEST_RUN='-test.run=TestGetAPIVersion'
+TEST_CASES=EGSL_HOUSTB200_LAB:/home/docker/creds.env \
+ONEVIEW_DEBUG=true \
+   make test-case TEST_RUN='-test.run=TestGetAPIVersion'
+```
+
+Run a single test without docker
+------------------------------
+Setup the libraries, example:
+```
+cp -R vendor/* /home/docker/go/src/
+ln -s /home/docker/git/github.com/HewlettPackard/oneview-golang /home/docker/go/src/github.com/HewlettPackard/oneview-golang
+```
+
+Run a Test
+```bash
+TEST_CASES=EGSL_HOUSTB200_LAB:/home/docker/creds.env \
+USE_CONTAINER=false \
+ONEVIEW_DEBUG=true \
+   make test-acceptance TEST_RUN='-test.run=TestGetAPIVersion'
 ```
 
 Updating external dependencies
@@ -92,8 +110,8 @@ curl https://glide.sh/get | sh
    ```
 
 4. Evaluate changes.
-   At this point you might have changes to the dependent libraries that have 
-   to be incorporated into the build process.   Update any additional or 
+   At this point you might have changes to the dependent libraries that have
+   to be incorporated into the build process.   Update any additional or
    no longer libraries by editing the file : [glide.yaml](glide.yaml).  
    This file contains all needed packages.
    Whenever adjusting libraries, make sure to re-do steps 1-3 iteratively.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,26 @@ define noop_targets
 	@make -pn | sed -rn '/^[^# \t\.%].*:[^=]?/p'|grep -v '='| grep -v '(%)'| grep -v '/'| awk -F':' '{print $$1}'|sort -u;
 endef
 
+define setup_testcase_creds
+  if [ ! -z "$(TEST_CASES)" ]; then \
+    test_cred=$$(echo '$(TEST_CASES)'| awk -F':' '{print $$2}'); \
+    test_dir=$$(dirname $$test_cred); \
+    echo "setting up testcases cred for container test acceptance"; \
+    test -z "$(shell docker ps -a --format '{{.Names}}' | grep '$(DOCKER_IMAGE_NAME)$$')" || \
+      docker rm -f $(DOCKER_IMAGE_NAME);  \
+    test -z "$(shell docker ps -a --format '{{.Names}}' | grep 'oneview-golang-testaccept$$')" || \
+      docker rm -f oneview-golang-testaccept;  \
+    test -z "$(shell docker volume ls | awk '{print $2}' | grep 'oneview-golang-testcreds$$')" || \
+      docker volume rm oneview-golang-testcreds; \
+    docker create -v oneview-golang-testcreds:$$test_dir --name oneview-golang-testaccept alpine sh; \
+    docker cp $$test_cred oneview-golang-testaccept:$$test_cred; \
+  else \
+    echo "skipping no test_cases to setup creds for"; \
+  fi
+endef
+
+GET_TESTCASE_VOLUME ?= $(shell [ ! -z "$(TEST_CASES)" ] && echo "--volumes-from oneview-golang-testaccept")
+
 include Makefile.inc
 
 ifneq (,$(findstring test-integration,$(MAKECMDGOALS)))
@@ -20,7 +40,6 @@ DOCKER_CONTAINER_NAME := oneview-golang-build-container
 DOCKER_FILE_URL := file://$(PREFIX)/Dockerfile
 DOCKER_FILE := .dockerfile.oneview
 
-
 noop:
 	@echo When using 'USE_CONTAINER' use a "make <target>"
 	@echo
@@ -29,7 +48,19 @@ noop:
 	$(call noop_targets)
 
 clean: gen-dockerfile
+
+# use this to run a single test case
+# ie;
+# TEST_CASES=EGSL_HOUSTB200_LAB:/home/docker/git/\
+# github.com/HewlettPackard/docker-machine-oneview\
+# /tools/oneview-machine/creds.env \
+# ONEVIEW_DEBUG=true make test-case TEST_RUN='-test.run=TestGetAPIVersion'
+test-case: gen-dockerfile
+	@$(call setup_testcase_creds)
+	make test-acceptance TEST_RUN='-test.run=TestGetAPIVersion'
+
 test: gen-dockerfile
+
 %:
 		export GO15VENDOREXPERIMENT=1
 		docker build -f $(DOCKER_FILE) -t $(DOCKER_IMAGE_NAME) .
@@ -37,6 +68,7 @@ test: gen-dockerfile
 		test -z '$(shell docker ps -a | grep $(DOCKER_CONTAINER_NAME))' || docker rm -f $(DOCKER_CONTAINER_NAME)
 
 		docker run --name $(DOCKER_CONTAINER_NAME) \
+		    $(GET_TESTCASE_VOLUME) \
 		    -e DEBUG \
 		    -e STATIC \
 		    -e VERBOSE \
@@ -47,6 +79,7 @@ test: gen-dockerfile
 		    -e TARGET_ARCH \
 		    -e PREFIX \
 		    -e GO15VENDOREXPERIMENT \
+				-e TEST_CASES \
 		    -e TEST_RUN \
 		    -e ONEVIEW_DEBUG \
 		    -e GH_USER \

--- a/icsp/api_version_test.go
+++ b/icsp/api_version_test.go
@@ -23,8 +23,8 @@ func TestGetAPIVersion(t *testing.T) {
 		// fmt.Printf("after GetAPIVersion: %s -> (err) %s", data.CurrentVersion, err)
 		// assert.Error(t,err, fmt.Sprintf("Error caught as expected: %s",err))
 		assert.NoError(t, err, "GetAPIVersion threw error -> %s", err)
-		assert.True(t, d.Tc.EqualFaceI(d.Tc.GetExpectsData(d.Env+"_icsp", "CurrentVersion"), data.CurrentVersion))
-		assert.True(t, d.Tc.EqualFaceI(d.Tc.GetExpectsData(d.Env+"_icsp", "MinimumVersion"), data.MinimumVersion))
+		assert.True(t, d.Tc.IsGreaterEqual(data.CurrentVersion, d.Tc.GetExpectsData(d.Env+"_icsp", "CurrentVersion")))
+		assert.True(t, d.Tc.IsGreaterEqual(data.MinimumVersion, d.Tc.GetExpectsData(d.Env+"_icsp", "MinimumVersion")))
 	} else {
 		_, c = getTestDriverU()
 		data, err := c.GetAPIVersion()

--- a/liboneview/api_support.go
+++ b/liboneview/api_support.go
@@ -64,9 +64,9 @@ func (o APISupport) New(i int) APISupport {
 func (o APISupport) IsSupported(v Version) bool {
 	switch o {
 	case C_SERVER_HARDWAREV2:
-		return API_VER2 == v
+		return (API_VER2 == v) || (API_VER_UNKNOWN == v) // adding unkonw to assume this is the latest
 	case C_PROFILE_TEMPLATES:
-		return API_VER2 == v
+		return (API_VER2 == v) || (API_VER_UNKNOWN == v) // lets assume this is the latest
 	default:
 		return true
 	}

--- a/liboneview/api_support_test.go
+++ b/liboneview/api_support_test.go
@@ -39,10 +39,10 @@ func TestIsSupported(t *testing.T) {
 	assert.True(t, asc.IsSupported(currentversion)) // should be true for any version
 
 	asc = asc.New(asc.Get("profile_templates.go"))
-	assert.True(t, (asc == C_PROFILE_TEMPLATES))      // is same as C_PROFILE_TEMPLATES
-	assert.False(t, asc.IsSupported(currentversion))  // should be false for ver1
-	assert.True(t, asc.IsSupported(API_VER2))         // should be true for ver2
-	assert.False(t, asc.IsSupported(API_VER_UNKNOWN)) // should be false if we don't know the version
+	assert.True(t, (asc == C_PROFILE_TEMPLATES))     // is same as C_PROFILE_TEMPLATES
+	assert.False(t, asc.IsSupported(currentversion)) // should be false for ver1
+	assert.True(t, asc.IsSupported(API_VER2))        // should be true for ver2
+	assert.True(t, asc.IsSupported(API_VER_UNKNOWN)) // should still be supported just unkown
 
 	// simulate client versions
 	var clientversion Version

--- a/liboneview/version_test.go
+++ b/liboneview/version_test.go
@@ -21,11 +21,15 @@ func TestCalculateVersion(t *testing.T) {
 	log.Debugf("v => %+v, %d", v, v.Integer())
 	assert.False(t, API_VER1.EqualV(v))       // should not be ver1
 	assert.False(t, API_VER2.EqualV(v))       // should not be ver2
-	assert.True(t, API_VER_UNKNOWN.EqualV(v)) // should not be ver2
+	assert.True(t, API_VER_UNKNOWN.EqualV(v)) // should be unkown
 
 	v = v.CalculateVersion(200, 108)
-	assert.False(t, API_VER1.EqualV(v)) // should be ver1
-	assert.True(t, API_VER2.EqualV(v))  // should not be ver2
+	assert.False(t, API_VER1.EqualV(v)) // should not be ver1
+	assert.True(t, API_VER2.EqualV(v))  // should be ver2
+
+	v = v.CalculateVersion(201, 108)
+	assert.False(t, API_VER1.EqualV(v))       // should not be ver1
+	assert.True(t, API_VER_UNKNOWN.EqualV(v)) // should unkown
 }
 
 // Test GetAPIVersion

--- a/ov/api_version_test.go
+++ b/ov/api_version_test.go
@@ -23,8 +23,8 @@ func TestGetAPIVersion(t *testing.T) {
 		// fmt.Printf("after GetAPIVersion: %s -> (err) %s", data.CurrentVersion, err)
 		// assert.Error(t,err, fmt.Sprintf("Error caught as expected: %s",err))
 		assert.NoError(t, err, "GetAPIVersion threw error -> %s", err)
-		assert.Equal(t, true, d.Tc.EqualFaceI(d.Tc.GetExpectsData(d.Env, "CurrentVersion"), data.CurrentVersion))
-		assert.Equal(t, true, d.Tc.EqualFaceI(d.Tc.GetExpectsData(d.Env, "MinimumVersion"), data.MinimumVersion))
+		assert.True(t, d.Tc.IsGreaterEqual(data.CurrentVersion, d.Tc.GetExpectsData(d.Env, "CurrentVersion")))
+		assert.True(t, d.Tc.IsGreaterEqual(data.MinimumVersion, d.Tc.GetExpectsData(d.Env, "MinimumVersion")))
 	} else {
 		_, c = getTestDriverU("dev")
 		data, err := c.GetAPIVersion()

--- a/ov/server_hardware.go
+++ b/ov/server_hardware.go
@@ -123,17 +123,18 @@ type ServerHardware struct {
 func (h ServerHardware) GetIloIPAddress() string {
 	if h.Client.IsHardwareSchemaV2() {
 		if h.MpHostInfo != nil {
-			log.Debug("working on getting IloIPAddress from MpHostInfo")
-			for _, MpIpObj := range h.MpHostInfo.MpIPAddress {
-				if len(MpIpObj.Address) > 0 &&
-					(MpDHCP.Equal(MpIpObj.Type) ||
-						MpStatic.Equal(MpIpObj.Type) ||
-						MpUndefined.Equal(MpIpObj.Type)) {
-					return MpIpObj.Address
+			log.Debug("working on getting IloIPAddress from MpHostInfo using v2")
+			for _, MpIPObj := range h.MpHostInfo.MpIPAddress {
+				if len(MpIPObj.Address) > 0 &&
+					(MpDHCP.Equal(MpIPObj.Type) ||
+						MpStatic.Equal(MpIPObj.Type) ||
+						MpUndefined.Equal(MpIPObj.Type)) {
+					return MpIPObj.Address
 				}
 			}
 		}
 	} else {
+		log.Debug("working on getting IloIPAddress from MpIpAddress")
 		return h.MpIpAddress
 	}
 	return ""

--- a/ov/server_hardware_test.go
+++ b/ov/server_hardware_test.go
@@ -75,10 +75,10 @@ func TestGetIloIPAddress(t *testing.T) {
 			t.Fatalf("Failed to execute getTestDriver() ")
 		}
 		s, err := c.GetServerHardware(testData)
+		assert.NoError(t, err, "GetServerHardware threw error -> %s", err)
 		ip := s.GetIloIPAddress()
 		log.Debugf("server -> %+v", s)
 		log.Debugf("ip -> %+v", ip)
-		assert.NoError(t, err, "GetServerHardware threw error -> %s", err)
 		assert.Equal(t, expectsData, ip)
 
 	}

--- a/test/data/config_EGSL_tb200.json
+++ b/test/data/config_EGSL_tb200.json
@@ -47,10 +47,10 @@
         "TemplateProfile": "Dev Docker Host",
         "SerialNumber": "VCGM123023",
         "MacAddr": "AA:43:83:10:00:BB",
-        "UsedBladeName": "02-CN751500Z9, bay 4",
-        "ServerHardwareURI": "/rest/server-hardware/36343537-3338-4E43-3735-313830303548",
-        "ServerProfileName": "Frame2, Bay 4 Gold",
-        "HardwareTypeURI": "/rest/server-hardware-types/01B10F88-4BF6-4A02-9065-DC9468008573",
+        "UsedBladeName": "HOUEGSL-C7000-05, bay 10",
+        "ServerHardwareURI": "/rest/server-hardware/30373237-3132-4D32-3235-333830575438",
+        "ServerProfileName": "wenlock-machine-1",
+        "HardwareTypeURI": "/rest/server-hardware-types/486B9A87-FCEB-4E9E-9E50-B0F54FAA0903",
         "GroupURI": "/rest/enclosure-groups/e0ee00e0-38bc-47e3-a4fe-bf6d13ce4cd2",
         "OSBuildPlan":"RHEL71_DOCKER_1.8"
       },
@@ -61,7 +61,7 @@
         "FakeData": "foo",
         "IcspName" : "IC04-HOUEGSL-C7000-04-4",
         "SerialNumber": "VCGM123023",
-        "IloIPAddress":  "16.85.0.90"
+        "IloIPAddress":  "16.85.0.59"
       }
     },
     {

--- a/testconfig/testcases.go
+++ b/testconfig/testcases.go
@@ -27,13 +27,71 @@ type TestCases struct {
 	ExpectsData map[string]interface{} `json:"expects_data,omitempty"` // map[string]interface{}{"expects_data": []interface{}}
 }
 
-// compare test data to a int num
-func (tc *TestConfig) EqualFaceI(f interface{}, i int) bool {
-	// convert the int to a float
-	return float64(f.(float64)) == float64(i)
+// IsGreaterEqual source greater or equal than target
+func (tc *TestConfig) IsGreaterEqual(source interface{}, target interface{}) bool {
+	return tc.Equal(source, target) || tc.IsGreater(source, target)
 }
 
-// Compare interface to string
+// IsGreater source number greater than target
+func (tc *TestConfig) IsGreater(source interface{}, target interface{}) bool {
+	var a, b float64
+
+	switch ts := source.(type) {
+	case int:
+		a = float64(source.(int))
+	case float64:
+		a = float64(source.(float64))
+	default:
+		_ = ts
+		return false
+	}
+
+	switch ts := target.(type) {
+	case int:
+		b = float64(target.(int))
+	case float64:
+		b = float64(target.(float64))
+	default:
+		_ = ts
+		return false
+	}
+
+	return a > b
+}
+
+// Equal determin numeric type and determine equality
+func (tc *TestConfig) Equal(source interface{}, target interface{}) bool {
+	var a, b float64
+	switch ts := source.(type) {
+	case int:
+		a = float64(source.(int))
+	case float64:
+		a = float64(source.(float64))
+	default:
+		_ = ts
+		return false
+	}
+
+	switch ts := target.(type) {
+	case int:
+		b = float64(target.(int))
+	case float64:
+		b = float64(target.(float64))
+	default:
+		_ = ts
+		return false
+	}
+
+	return (a == b)
+}
+
+// EqualFaceI compare test data to a int num
+func (tc *TestConfig) EqualFaceI(f interface{}, i int) bool {
+	// convert the int to a float
+	return tc.Equal(f, i)
+}
+
+// EqualFaceS Compare interface to string
 // doesn't seem to really be needed....
 func (tc *TestConfig) EqualFaceS(is interface{}, s string) bool {
 	// convert the int to a float


### PR DESCRIPTION
Newer versions of OneView are not being
detected as v2 api.   This loosens the
v2 version detection to include unkown versions
in favor of using v2 api.

- add some test case methods for equality testing
- provide some methods for testing in docker
- update acceptance test case for dev on new hw

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>