### PR TITLE
Add Image Streamer API support

### DIFF
--- a/i3s/i3s.go
+++ b/i3s/i3s.go
@@ -1,0 +1,40 @@
+/*
+(c) Copyright [2015] Hewlett Packard Enterprise Development LP
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package i3s - Image Streamer 3.0 -
+package i3s
+
+import "github.com/HewlettPackard/oneview-golang/rest"
+
+// I3SClient - wrapper class for i3s api's
+type I3SClient struct {
+	rest.Client
+}
+
+// new Client
+func (c *I3SClient) NewI3SClient(user string, password string, domain string, endpoint string, sslverify bool, apiversion int) *I3SClient {
+	return &I3SClient{
+		rest.Client{
+			User:       user,
+			Password:   password,
+			Domain:     domain,
+			Endpoint:   endpoint,
+			SSLVerify:  sslverify,
+			APIVersion: apiversion,
+			APIKey:     "none",
+		},
+	}
+}

--- a/i3s/i3s_test.go
+++ b/i3s/i3s_test.go
@@ -1,0 +1,85 @@
+package i3s
+
+import (
+	"os"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/rest"
+	"github.com/HewlettPackard/oneview-golang/testconfig"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/stretchr/testify/assert"
+)
+
+type I3STest struct {
+	Tc     *testconfig.TestConfig
+	Client *I3SClient
+	Env    string
+}
+
+// get Environment
+func (ot *I3STest) GetEnvironment() {
+	if os.Getenv("ONEVIEW_TEST_ENV") != "" {
+		ot.Env = os.Getenv("ONEVIEW_TEST_ENV")
+		return
+	}
+	ot.Env = "dev"
+	return
+}
+
+// get a test driver for acceptance testing
+func getTestDriverA() (*I3STest, *I3SClient) {
+	// os.Setenv("DEBUG", "true")  // remove comment to debug logs
+	var ot *I3STest
+	var tc *testconfig.TestConfig
+	ot = &I3STest{Tc: tc.NewTestConfig(), Env: "dev"}
+	ot.GetEnvironment()
+	ot.Tc.GetTestingConfiguration(os.Getenv("ONEVIEW_TEST_DATA"))
+	ot.Client = &I3SClient{
+		rest.Client{
+			User:     os.Getenv("ONEVIEW_I3S_USER"),
+			Password: os.Getenv("ONEVIEW_I3S_PASSWORD"),
+			Domain:   os.Getenv("ONEVIEW_I3S_DOMAIN"),
+			Endpoint: os.Getenv("ONEVIEW_I3S_ENDPOINT"),
+			// ConfigDir:
+			SSLVerify: false,
+			APIKey:    "none",
+		},
+	}
+	// TODO: implement ot.Client.RefreshVersion()
+	return ot, ot.Client
+}
+
+// Unit test
+func getTestDriverU() (*I3STest, *I3SClient) {
+	var ot *I3STest
+	var tc *testconfig.TestConfig
+	ot = &I3STest{Tc: tc.NewTestConfig(), Env: "dev"}
+	ot.GetEnvironment()
+	ot.Tc.GetTestingConfiguration(os.Getenv("ONEVIEW_TEST_DATA"))
+	ot.Client = &I3SClient{
+		rest.Client{
+			User:       "foo",
+			Password:   "bar",
+			Domain:     "LOCAL",
+			Endpoint:   "https://i3stestcase",
+			SSLVerify:  false,
+			APIVersion: 300,
+			APIKey:     "none",
+		},
+	}
+	return ot, ot.Client
+}
+
+// Test Getting New I3SClient
+func TestNewI3SClient(t *testing.T) {
+	var (
+		c *I3SClient
+	)
+	log.Debug("implements unit test for TestNewI3SClient")
+	if os.Getenv("I3S_TEST_ACCEPTANCE") == "true" {
+		_, c = getTestDriverA()
+	} else {
+		_, c = getTestDriverU()
+	}
+	assert.True(t, (c != nil), "Failed to get proper client")
+}

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -3,7 +3,7 @@ GO_LDFLAGS := -X `go list ./version`.GitCommit=`git rev-parse --short HEAD`
 GO_GCFLAGS :=
 
 # Full package list
-PKGS := ./testconfig ./ov ./icsp ./liboneview ./rest ./utils
+PKGS := ./testconfig ./ov ./icsp ./i3s ./liboneview ./rest ./utils
 
 # Resolving binary dependencies for specific targets
 GOLINT_BIN := $(GOPATH)/bin/golint


### PR DESCRIPTION
Lets start working on Image Streamer 3.0 (I3S)
This work will be introduced as several PR's
subsequent to this one.  Goal for this PR
is to establish the new folder, and entry-point
client for the i3s portoion of the goland sdk.

- adds new package and testing called i3s, so now
  we have an I3SClient to work with.

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>