### PR TITLE
Update task.go

### DIFF
--- a/ov/task.go
+++ b/ov/task.go
@@ -169,7 +169,7 @@ func (t *Task) NewProfileTask(c *OVClient) *Task {
 		URI:      "",
 		Name:     "",
 		Owner:    "",
-		Timeout:  144, // default 24min
+		Timeout:  270, // default 45min
 		WaitTime: 10}  // default 10sec, impacts Timeout
 }
 


### PR DESCRIPTION
Changing Timeout settings since OneView isn't handling servers sequentially 

Signed-off-by: Matthew Frahry <matthew.frahry@hpe.com>