### PR TITLE
Remove reflection from the package. Minor opts.

### DIFF
--- a/rest/netutil.go
+++ b/rest/netutil.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/docker/machine/libmachine/log"
@@ -33,7 +32,7 @@ var (
 	}
 
 	// get a client
-	client = &http.Client{Transport: tr, Timeout: 5 * time.Minute}
+	client = &http.Client{Transport: tr}
 )
 
 // Options for REST call

--- a/rest/netutil.go
+++ b/rest/netutil.go
@@ -8,10 +8,32 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"reflect"
+	"time"
 
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/docker/machine/libmachine/log"
+)
+
+var (
+	codes = map[int]bool{
+		http.StatusOK:                  true,
+		http.StatusCreated:             true,
+		http.StatusAccepted:            true,
+		http.StatusNoContent:           true,
+		http.StatusBadRequest:          false,
+		http.StatusNotFound:            false,
+		http.StatusNotAcceptable:       false,
+		http.StatusConflict:            false,
+		http.StatusInternalServerError: false,
+	}
+
+	// TODO: this should have a real cert
+	tr = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	// get a client
+	client = &http.Client{Transport: tr, Timeout: 5 * time.Minute}
 )
 
 // Options for REST call
@@ -35,24 +57,11 @@ type Client struct {
 
 // NewClient - get a new network client
 func (c *Client) NewClient(user, key, endpoint string) *Client {
-	var options Options
-	return &Client{User: user, APIKey: key, Endpoint: endpoint, Option: options}
+	return &Client{User: user, APIKey: key, Endpoint: endpoint, Option: Options{}}
 }
 
 // isOkStatus - check the return status of the response
 func (c *Client) isOkStatus(code int) bool {
-	codes := map[int]bool{
-		200: true,
-		201: true,
-		202: true,
-		204: true,
-		400: false,
-		404: false,
-		500: false,
-		409: false,
-		406: false,
-	}
-
 	return codes[code]
 }
 
@@ -69,9 +78,8 @@ func (c *Client) GetQueryString(u *url.URL) {
 	}
 	parameters := url.Values{}
 	for k, v := range c.Option.Query {
-		var r []string
-		if reflect.TypeOf(v) == reflect.TypeOf(r) {
-			for _, va := range v.([]string) {
+		if val, ok := v.([]string); ok {
+			for _, va := range val {
 				parameters.Add(k, va)
 			}
 		} else {
@@ -105,14 +113,6 @@ func (c *Client) RestAPICall(method Method, path string, options interface{}) ([
 
 	// Manage the query string
 	c.GetQueryString(Url)
-
-	// TODO: this should have a real cert
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	// get a client
-	client := &http.Client{Transport: tr}
 
 	log.Debugf("*** url => %s", Url.String())
 	log.Debugf("*** method => %s", method.String())

--- a/testconfig/testcases.go
+++ b/testconfig/testcases.go
@@ -36,23 +36,21 @@ func (tc *TestConfig) IsGreaterEqual(source interface{}, target interface{}) boo
 func (tc *TestConfig) IsGreater(source interface{}, target interface{}) bool {
 	var a, b float64
 
-	switch ts := source.(type) {
+	switch source.(type) {
 	case int:
 		a = float64(source.(int))
 	case float64:
 		a = float64(source.(float64))
 	default:
-		_ = ts
 		return false
 	}
 
-	switch ts := target.(type) {
+	switch target.(type) {
 	case int:
 		b = float64(target.(int))
 	case float64:
 		b = float64(target.(float64))
 	default:
-		_ = ts
 		return false
 	}
 
@@ -62,23 +60,21 @@ func (tc *TestConfig) IsGreater(source interface{}, target interface{}) bool {
 // Equal determin numeric type and determine equality
 func (tc *TestConfig) Equal(source interface{}, target interface{}) bool {
 	var a, b float64
-	switch ts := source.(type) {
+	switch source.(type) {
 	case int:
 		a = float64(source.(int))
 	case float64:
 		a = float64(source.(float64))
 	default:
-		_ = ts
 		return false
 	}
 
-	switch ts := target.(type) {
+	switch target.(type) {
 	case int:
 		b = float64(target.(int))
 	case float64:
 		b = float64(target.(float64))
 	default:
-		_ = ts
 		return false
 	}
 

--- a/utils/stringy.go
+++ b/utils/stringy.go
@@ -3,11 +3,14 @@ package utils
 import "regexp"
 
 // some general string function helpers
+var (
+	reRemoveJSON = regexp.MustCompile("(.*)({.*}).*")
+	reGetJSON    = regexp.MustCompile("(.*)({.*}).*")
+)
 
 // StringRemoveJSON - remove a json string from regular strings
 func StringRemoveJSON(s string) string {
-	r := regexp.MustCompile("(.*)({.*}).*")
-	a := r.FindStringSubmatch(s)
+	a := reRemoveJSON.FindStringSubmatch(s)
 	if len(a) > 2 {
 		return StringRemoveJSON(a[1]) // keep trying to remove json till there is no more left
 	}
@@ -17,8 +20,7 @@ func StringRemoveJSON(s string) string {
 // StringGetJSON - just get the JSON from the string
 //                 should only find the first json
 func StringGetJSON(s string) string {
-	r := regexp.MustCompile("(.*)({.*}).*")
-	a := r.FindStringSubmatch(s)
+	a := reGetJSON.FindStringSubmatch(s)
 	if len(a) > 2 {
 		return a[2]
 	}


### PR DESCRIPTION
Hello!

I made a couple of minor modifications here. Some are just best practices (although I'm not sure if you guys accept package-level vars), and others are just functional improvements.

* I removed reflection from the package, since it was pretty much not needed. There was a type casting so that saves a couple of keystrokes plus makes it more resilient, and avoid creating a slice.
* I moved the client and transport to a package-level rather than function level, this is so you can reuse the same client and prevent some nasty problems when creating it multiple times. This also allows to reuse the same transport mechanism.

I'm @mbfrahry's coworker btw.