### PR TITLE
Add more tests. Avoid casting bytes from the response.

### DIFF
--- a/ov/fc_network.go
+++ b/ov/fc_network.go
@@ -85,7 +85,7 @@ func (c *OVClient) CreateFCNetwork(fcNet FCNetwork) error {
 	log.Infof("Initializing creation of fc network for %s.", fcNet.Name)
 	var (
 		uri = "/rest/fc-networks"
-		t   = t.NewProfileTask(c)
+		t   = (&Task{}).NewProfileTask(c)
 	)
 	// refresh login
 	c.RefreshLogin()

--- a/ov/fc_network.go
+++ b/ov/fc_network.go
@@ -39,24 +39,21 @@ type FCNetworkList struct {
 }
 
 func (c *OVClient) GetFCNetworkByName(name string) (FCNetwork, error) {
-	var (
-		fcNet FCNetwork
-	)
 	fcNets, err := c.GetFCNetworks(fmt.Sprintf("name matches '%s'", name), "name:asc")
 	if fcNets.Total > 0 {
 		return fcNets.Members[0], err
-	} else {
-		return fcNet, err
 	}
+
+	return FCNetwork{}, err
 }
 
 func (c *OVClient) GetFCNetworks(filter string, sort string) (FCNetworkList, error) {
 	var (
 		uri        = "/rest/fc-networks"
-		q          map[string]interface{}
+		q          = make(map[string]interface{})
 		fcNetworks FCNetworkList
 	)
-	q = make(map[string]interface{})
+
 	if len(filter) > 0 {
 		q["filter"] = filter
 	}
@@ -78,7 +75,7 @@ func (c *OVClient) GetFCNetworks(filter string, sort string) (FCNetworkList, err
 	}
 
 	log.Debugf("GetfcNetworks %s", data)
-	if err := json.Unmarshal([]byte(data), &fcNetworks); err != nil {
+	if err := json.Unmarshal(data, &fcNetworks); err != nil {
 		return fcNetworks, err
 	}
 	return fcNetworks, nil
@@ -88,13 +85,12 @@ func (c *OVClient) CreateFCNetwork(fcNet FCNetwork) error {
 	log.Infof("Initializing creation of fc network for %s.", fcNet.Name)
 	var (
 		uri = "/rest/fc-networks"
-		t   *Task
+		t   = t.NewProfileTask(c)
 	)
 	// refresh login
 	c.RefreshLogin()
 	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
 
-	t = t.NewProfileTask(c)
 	t.ResetTask()
 	log.Debugf("REST : %s \n %+v\n", uri, fcNet)
 	log.Debugf("task -> %+v", t)
@@ -106,7 +102,7 @@ func (c *OVClient) CreateFCNetwork(fcNet FCNetwork) error {
 	}
 
 	log.Debugf("Response New fcNetwork %s", data)
-	if err := json.Unmarshal([]byte(data), &t); err != nil {
+	if err := json.Unmarshal(data, &t); err != nil {
 		t.TaskIsDone = true
 		log.Errorf("Error with task un-marshal: %s", err)
 		return err
@@ -151,7 +147,7 @@ func (c *OVClient) DeleteFCNetwork(name string) error {
 		}
 
 		log.Debugf("Response delete fc network %s", data)
-		if err := json.Unmarshal([]byte(data), &t); err != nil {
+		if err := json.Unmarshal(data, &t); err != nil {
 			t.TaskIsDone = true
 			log.Errorf("Error with task un-marshal: %s", err)
 			return err
@@ -189,7 +185,7 @@ func (c *OVClient) UpdateFcNetwork(fcNet FCNetwork) error {
 	}
 
 	log.Debugf("Response Update FCNetwork %s", data)
-	if err := json.Unmarshal([]byte(data), &t); err != nil {
+	if err := json.Unmarshal(data, &t); err != nil {
 		t.TaskIsDone = true
 		log.Errorf("Error with task un-marshal: %s", err)
 		return err

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -4,10 +4,7 @@ import "strings"
 
 // Sanatize ...
 func Sanatize(s string) string {
-	if strings.LastIndex(s, "/") > 0 {
-		s = strings.Trim(s, "/")
-	}
-	return s
+	return strings.TrimRight(s, "/")
 }
 
 // IsEmpty ...

--- a/utils/helpers_test.go
+++ b/utils/helpers_test.go
@@ -1,1 +1,39 @@
 package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+var trimtests = map[string]string{
+	"///string///":                 "///string",
+	"http://www.example.com/test/": "http://www.example.com/test",
+	"string":                       "string",
+}
+
+var emptytests = map[string]bool{
+	"":       true,
+	"abc123": false,
+	"🤘🏻":     false,
+}
+
+func TestStringTrimming(t *testing.T) {
+	for original, expected := range trimtests {
+		if result := Sanatize(original); result != expected {
+			t.Logf("Expected %q but received %q instead.", expected, result)
+			t.Fail()
+		}
+	}
+}
+
+func TestEmpties(t *testing.T) {
+	for value, expected := range emptytests {
+		if empty := IsEmpty(value); empty != expected {
+			t.Logf(
+				"String %q expected empty to be %q, got %q instead",
+				value, fmt.Sprintf("%s", expected), fmt.Sprintf("%s", empty),
+			)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
Hello everyone,

With a bit of free time, I added two more simple tests, but also changed some things:

When `json.Unmarshal()`ing, there was a cast to take `data` which is the http response, to be casted to `[]byte`. This was not needed since the value is already a byte slice. I did it in one file, just to see, then I can propagate the same change to all other files.

I rewrote the (incorrectly spelled) `Sanatize()` function based on the condition... Previously, it was...

```go
func Sanatize(s string) string {
	if strings.LastIndex(s, "/") > 0 {
		s = strings.Trim(s, "/")
	}
	return s
 }
```

... Which I understand as: if it ends in `/` then remove them. The problem is that `Trim()` not only removes the final slashes, but also the ones at the beginning. I rewrote it so it only accounts for those at the end. 

I didn't want to change how it's spelled since it may break any code consuming that function.