### PR TITLE
remove hard coded deployment network call

### DIFF
--- a/ov/connectionv3.go
+++ b/ov/connectionv3.go
@@ -23,12 +23,13 @@ import (
 	"strings"
 )
 
-func (c *OVClient) ManageI3SConnections(connections []Connection) ([]Connection, error) {
+// ManageI3SConnections - setup connections for i3s deployment network
+func (c *OVClient) ManageI3SConnections(connections []Connection, netname string) ([]Connection, error) {
 
 	//Find the deploy net called deploy.net
-	deployNet, err := c.GetEthernetNetworkByName("deploy.net")
+	deployNet, err := c.GetEthernetNetworkByName(netname)
 	if err != nil || deployNet.URI.IsNil() {
-		return connections, fmt.Errorf("Could not find deployment ethernet network name: deploy.net")
+		return connections, fmt.Errorf("Could not find deployment ethernet network name: %s", netname)
 	}
 
 	//This section finds which PortIds we have available so we can apply new port ids to connections that have the boot PortIds(Which the boot connections need).

--- a/ov/profilesv3.go
+++ b/ov/profilesv3.go
@@ -18,6 +18,7 @@ package ov
 
 import (
 	"fmt"
+
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/docker/machine/libmachine/log"
 )
@@ -106,7 +107,7 @@ type CustomizeServer struct {
 	ProfileName            string            // name of server
 	OSDeploymentBuildPlan  string            // name of the OS build plan
 	OSDeploymentAttributes map[string]string // name value pairs for server custom attributes
-
+	EthernetNetworkName    string            // deployment network name
 }
 
 // CustomizeServer - Customize Server
@@ -139,7 +140,7 @@ func (c *OVClient) CustomizeServer(cs CustomizeServer) error {
 	s.OSDeploymentSettings.OSDeploymentPlanUri = osDeploymentPlan.URI
 	s.OSDeploymentSettings.OSCustomAttributes = serverDeploymentAttributes
 
-	s.Connections, err = c.ManageI3SConnections(s.Connections)
+	s.Connections, err = c.ManageI3SConnections(s.Connections, cs.EthernetNetworkName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Lets change from a hard-coded deploy.net value to new custom attribute
that can help us identify the deployment network to use.  To be provided
by the consumer.