### PR TITLE
Support for HTTP "PATCH" Method

### DIFF
--- a/rest/method.go
+++ b/rest/method.go
@@ -8,6 +8,7 @@ const (
 	POST
 	PUT
 	DELETE
+	PATCH
 )
 
 var method = [...]string{
@@ -15,6 +16,7 @@ var method = [...]string{
 	"POST",
 	"PUT",
 	"DELETE",
+	"PATCH",
 }
 
 func (m Method) String() string { return method[m-1] }

--- a/rest/method_test.go
+++ b/rest/method_test.go
@@ -13,4 +13,5 @@ func TestMethod(t *testing.T) {
 	assert.Equal(t, "POST", POST.String(), "POST should be string")
 	assert.Equal(t, "PUT", PUT.String(), "PUT should be string")
 	assert.Equal(t, "DELETE", DELETE.String(), "DELETE should be string")
+	assert.Equal(t, "PATCH", PATCH.String(), "PATCH should be string")
 }


### PR DESCRIPTION
Adding an enhancement to Method within `github.com/HewlettPackard/oneview-golang/rest` package to allow for use of the OneView 310 RemoteSupport API.

Partial enhancement for [issue#38](https://github.com/HewlettPackard/oneview-golang/issues/38)