### PR TITLE
Show better error messages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 *.go text
 *.mk text
 *.json
+
+*.png binary

--- a/rest/netutil.go
+++ b/rest/netutil.go
@@ -176,11 +176,12 @@ func (c *Client) RestAPICall(method Method, path string, options interface{}) ([
 	data, err := ioutil.ReadAll(resp.Body)
 	if !c.isOkStatus(resp.StatusCode) {
 		type apiErr struct {
-			Err string `json:"details"`
+			Message string `json:"message"`
+			Details string `json:"details"`
 		}
 		var outErr apiErr
 		json.Unmarshal(data, &outErr)
-		return nil, fmt.Errorf("Error in response: %s\n Response Status: %s", outErr.Err, resp.Status)
+		return nil, fmt.Errorf("Error in response: %s\n Response Status: %s\n Response Details: %s", outErr.Message, resp.Status, outErr.Details)
 	}
 
 	if err != nil {


### PR DESCRIPTION
The currently displayed error messages aren't always easy to follow.  I have added some more details to the message to make troubleshooting a bit easier.

For example, this message from Terraform left me scratching my head a bit:
```
* oneview_logical_interconnect_group.lig: Error in response: Only one enclosure is present in the Logical Interconnect Group
 Response Status: 400 Bad Request
```

With this code, I get this error message with some more clarity:
```
* oneview_logical_interconnect_group.lig: Error in response: A Highly Available Logical Interconnect Group must contain at least 2 enclosures.
 Response Status: 400 Bad Request
 Response Details: Only one enclosure is present in the Logical Interconnect Group
```

I also updated .gitattributes to mark *.png files as binary.  Otherwise, my machine kept trying to change the line ending format on some graphics in one of the vendor libraries.
