### PR TITLE
changed the uplinkset struct name as it is not in sync with Rest API doc

### DIFF
--- a/ov/logical_interconnect_group.go
+++ b/ov/logical_interconnect_group.go
@@ -32,7 +32,7 @@ type LogicalInterconnectGroup struct {
 	Status                  string                   `json:"status,omitempty"`                 // "status": "Critical",
 	TelemetryConfiguration  *TelemetryConfiguration  `json:"telemetryConfiguration,omitempty"` // "telemetryConfiguration": {...},
 	Type                    string                   `json:"type"`                             // "type": "logical-interconnect-groupsV3",
-	UplinkSets              []UplinkSet              `json:"uplinkSets,omitempty"`             // "uplinkSets": {...},
+	UplinkSets              []UplinkSets              `json:"uplinkSets,omitempty"`             // "uplinkSets": {...},
 	URI                     utils.Nstring            `json:"uri,omitempty"`                    // "uri": "/rest/logical-interconnect-groups/e2f0031b-52bd-4223-9ac1-d91cb519d548",
 }
 
@@ -210,7 +210,7 @@ type TelemetryConfiguration struct {
 	URI             utils.Nstring `json:"uri,omitempty"`             // "uri": null
 }
 
-type UplinkSet struct {
+type UplinkSets struct {
 	EthernetNetworkType    string                  `json:"ethernetNetworkType,omitempty"` // "ethernetNetworkType": "Tagged",
 	LacpTimer              string                  `json:"lacpTimer,omitempty"`           // "lacpTimer": "Long",
 	LogicalPortConfigInfos []LogicalPortConfigInfo `json:"logicalPortConfigInfos"`        // "logicalPortConfigInfos": {...},

--- a/ov/logical_interconnect_group.go
+++ b/ov/logical_interconnect_group.go
@@ -32,7 +32,7 @@ type LogicalInterconnectGroup struct {
 	Status                  string                   `json:"status,omitempty"`                 // "status": "Critical",
 	TelemetryConfiguration  *TelemetryConfiguration  `json:"telemetryConfiguration,omitempty"` // "telemetryConfiguration": {...},
 	Type                    string                   `json:"type"`                             // "type": "logical-interconnect-groupsV3",
-	UplinkSets              []UplinkSets              `json:"uplinkSets,omitempty"`             // "uplinkSets": {...},
+	UplinkSets              []UplinkSets             `json:"uplinkSets,omitempty"`             // "uplinkSets": {...},
 	URI                     utils.Nstring            `json:"uri,omitempty"`                    // "uri": "/rest/logical-interconnect-groups/e2f0031b-52bd-4223-9ac1-d91cb519d548",
 }
 


### PR DESCRIPTION
Changed the Uplink_set struct name to Uplink_sets as it will be conflicting with the Uplink_set struct in Uplink_set resource file, and also naming as per rest API doc.

### Description
struct name change for Uplink_set in LIG API800

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for go 1.11 + gofmt checks .
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.

