### PR TITLE
Add support to LIG for configuring SNMPv3

### DIFF
--- a/ov/logical_interconnect_group.go
+++ b/ov/logical_interconnect_group.go
@@ -181,7 +181,8 @@ type SnmpConfiguration struct {
 	SystemContact    string            `json:"systemContact,omitempty"`    // "systemContact": "",
 	TrapDestinations []TrapDestination `json:"trapDestinations,omitempty"` // "trapDestinations": {...}
 	Type             string            `json:"type,omitempty"`             // "type": "snmp-configuration",
-	URI              utils.Nstring     `json:"uri,omitempty"`              // "uri": null
+	URI              utils.Nstring     `json:"uri,omitempty"`              // "uri": null,
+	V3Enabled        *bool             `json:"v3Enabled,omitempty"`        // "v3Enabled": true
 }
 
 type TrapDestination struct {


### PR DESCRIPTION
Per the API documentation, "For Virtual Connect SE 40Gb F8 Module, SNMPv3 cannot be disabled and it is enabled by default."

This commit adds the v3Enabled option to the SNMP structure for Logical Interconnect Groups.  Without this option, it is not possible to modify a Logical Interconnect Group using a Virtual Connect SE 40Gb F8 in Terraform.