### PR TITLE
corrected uplink struct and added missing parameter in ethernet struct

### DIFF
--- a/ov/ethernet_network.go
+++ b/ov/ethernet_network.go
@@ -23,6 +23,7 @@ type EthernetNetwork struct {
 	SmartLink             bool            `json:"smartLink"`                       // "smartLink": false,
 	State                 string          `json:"state,omitempty"`                 // "state": "Normal",
 	Status                string          `json:"status,omitempty"`                // "status": "Critical",
+	SubnetUri             utils.Nstring   `json:"subnetUri,omitempty"`             // "subnetUri": "",
 	Type                  string          `json:"type,omitempty"`                  // "type": "ethernet-networkV3",
 	URI                   utils.Nstring   `json:"uri,omitempty"`                   // "uri": "/rest/ethernet-networks/e2f0031b-52bd-4223-9ac1-d91cb519d548"
 	VlanId                int             `json:"vlanId,omitempty"`                // "vlanId": 1,

--- a/ov/uplink_set.go
+++ b/ov/uplink_set.go
@@ -20,7 +20,9 @@ type LocationEntries struct {
 
 type PortConfigInfos struct {
 	DesiredSpeed string   `json:"desiredSpeed,omitempty"` //"desiredSpeed":"Auto",
+        ExpectedNeighbor *ExpectedNeighbor `json:"expectedNeighbor"`  //"expectedNeighbor":"",
 	Location     Location `json:"location"`               //"location":"{...},
+	PortUri      string   `json:"portUri"`                //"portUri:"",
 }
 
 type ExpectedNeighbor struct {
@@ -47,8 +49,7 @@ type UplinkSet struct {
 	Etag                           string            `json:"eTag,omitempty"`                           // "eTag": "1441036118675/8",
 	Modified                       string            `json:"modified,omitempty"`                       // "modified": "20150831T154835.250Z",
 	LacpTimer                      string            `json:"lacpTimer,omitempty"`                      // "lacpTimer": "Long",
-	FcMode                         string            `json:"mode,omitempty"`                           // "mode": "TRUNK",
-	ExpectedNeighbor               *ExpectedNeighbor `json:"expectedNeighbor,omitempty"`               //"expectedNeighbor": ""
+	FcMode                         string            `json:"fcMode,omitempty"`                         // "fcMode": "TRUNK",
 	NativeNetworkUri               utils.Nstring     `json:"nativeNetworkUri,omitempty"`               // "nativeNetworkUri": null,
 	PrimaryPortLocation            *Location         `json:"primaryPort,omitempty"`                    // "primaryPort": {...},
 	Reachability                   string            `json:"reachability,omitempty"`                   // "reachability": "Reachable",

--- a/ov/uplink_set.go
+++ b/ov/uplink_set.go
@@ -19,10 +19,10 @@ type LocationEntries struct {
 }
 
 type PortConfigInfos struct {
-	DesiredSpeed string   `json:"desiredSpeed,omitempty"` //"desiredSpeed":"Auto",
-        ExpectedNeighbor *ExpectedNeighbor `json:"expectedNeighbor"`  //"expectedNeighbor":"",
-	Location     Location `json:"location"`               //"location":"{...},
-	PortUri      string   `json:"portUri"`                //"portUri:"",
+	DesiredSpeed     string            `json:"desiredSpeed,omitempty"` //"desiredSpeed":"Auto",
+	ExpectedNeighbor *ExpectedNeighbor `json:"expectedNeighbor"`       //"expectedNeighbor":"",
+	Location         Location          `json:"location"`               //"location":"{...},
+	PortUri          string            `json:"portUri"`                //"portUri:"",
 }
 
 type ExpectedNeighbor struct {


### PR DESCRIPTION
### Description
Corrected the Uplink set struct and added the missing parameter in Ethernet struct

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
