### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/icsp/deploymentjobs.go
+++ b/icsp/deploymentjobs.go
@@ -128,7 +128,7 @@ func (c *ICSPClient) SubmitDeploymentJobs(dj DeploymentJobs) (jt *JobTask, err e
 	return jt, err
 }
 
-// ApplyDeployment plan to server
+// ApplyDeploymentJobs plan to server
 func (c *ICSPClient) ApplyDeploymentJobs(buildplans []string, bpdata *OSDPersonalityDataV2, s Server) (jt *JobTask, err error) {
 
 	var dj DeploymentJobs

--- a/ov/os_deployment_plan.go
+++ b/ov/os_deployment_plan.go
@@ -50,7 +50,7 @@ type CustomAttribute struct {
 	Value         string `json:"value,omitempty"`         // "value": "attribute_value",
 }
 
-// get an os deployment plan with uri
+// GetOSDeploymentPlan gets an os deployment plan with uri
 func (c *OVClient) GetOSDeploymentPlan(uri utils.Nstring) (OSDeploymentPlan, error) {
 
 	var osDeploymentPlan OSDeploymentPlan

--- a/ov/power_state.go
+++ b/ov/power_state.go
@@ -101,7 +101,7 @@ func (pt *PowerTask) NewPowerTask(b ServerHardware) *PowerTask {
 	return pt
 }
 
-// get current power state
+// GetCurrentPowerState gets current power state
 func (pt *PowerTask) GetCurrentPowerState() error {
 	// Quick check to make sure we have a proper hardware blade
 	if pt.Blade.URI.IsNil() {

--- a/ov/profile_templates.go
+++ b/ov/profile_templates.go
@@ -48,7 +48,7 @@ func (c *OVClient) IsProfileTemplates() bool {
 	return !c.ProfileTemplatesNotSupported()
 }
 
-// get a server profile template by name
+// GetProfileTemplateByName gets a server profile template by name
 func (c *OVClient) GetProfileTemplateByName(name string) (ServerProfile, error) {
 	var (
 		profile ServerProfile
@@ -74,7 +74,7 @@ func (c *OVClient) GetProfileTemplateByName(name string) (ServerProfile, error) 
 
 }
 
-// get a server profiles
+// GetProfileTemplates gets a server profiles
 func (c *OVClient) GetProfileTemplates(start string, count string, filter string, sort string, scopeUris string) (ServerProfileList, error) {
 	var (
 		uri      = "/rest/server-profile-templates"

--- a/ov/profiles.go
+++ b/ov/profiles.go
@@ -160,7 +160,7 @@ type ServerProfileList struct {
 	Members     []ServerProfile `json:"members,omitempty"`     // "members":[]
 }
 
-// get a server profile by name
+// GetProfileByName gets a server profile by name
 func (c *OVClient) GetProfileByName(name string) (ServerProfile, error) {
 	var (
 		profile ServerProfile

--- a/ov/server_hardware.go
+++ b/ov/server_hardware.go
@@ -192,7 +192,7 @@ func (s ServerHardware) PowerOn() error {
 	return pt.PowerExecutor(P_ON)
 }
 
-// get the power state
+// GetPowerState gets the power state
 func (s ServerHardware) GetPowerState() (PowerState, error) {
 	var pt *PowerTask
 	pt = pt.NewPowerTask(s)
@@ -202,7 +202,7 @@ func (s ServerHardware) GetPowerState() (PowerState, error) {
 	return pt.State, nil
 }
 
-// get a server hardware with uri
+// GetServerHardwareByUri gets a server hardware with uri
 func (c *OVClient) GetServerHardwareByUri(uri utils.Nstring) (ServerHardware, error) {
 
 	var hardware ServerHardware
@@ -225,7 +225,7 @@ func (c *OVClient) GetServerHardwareByUri(uri utils.Nstring) (ServerHardware, er
 	return hardware, nil
 }
 
-// get a server hardware with uri
+// GetServerHardwareByName gets a server hardware with uri
 func (c *OVClient) GetServerHardwareByName(name string) (ServerHardware, error) {
 
 	var (
@@ -242,7 +242,7 @@ func (c *OVClient) GetServerHardwareByName(name string) (ServerHardware, error) 
 	}
 }
 
-// get a server hardware with filters
+// GetServerHardwareList gets a server hardware with filters
 func (c *OVClient) GetServerHardwareList(filters []string, sort string) (ServerHardwareList, error) {
 	var (
 		uri        = "/rest/server-hardware"
@@ -278,7 +278,7 @@ func (c *OVClient) GetServerHardwareList(filters []string, sort string) (ServerH
 	return serverlist, nil
 }
 
-// get available server
+// GetAvailableHardware gets available server
 // blades = rest_api(:oneview, :get, "/rest/server-hardware?sort=name:asc&filter=serverHardwareTypeUri='#{server_hardware_type_uri}'&filter=serverGroupUri='#{enclosure_group_uri}'")
 func (c *OVClient) GetAvailableHardware(hardwaretype_uri utils.Nstring, servergroup_uri utils.Nstring) (hw ServerHardware, err error) {
 	var (
@@ -306,7 +306,7 @@ func (c *OVClient) GetAvailableHardware(hardwaretype_uri utils.Nstring, servergr
 	return hw, nil
 }
 
-// get firmware for a server hardware with uri
+// GetServerFirmwareByUri gets firmware for a server hardware with uri
 func (c *OVClient) GetServerFirmwareByUri(uri utils.Nstring) (ServerFirmware, error) {
 
 	var (

--- a/rest/netutil.go
+++ b/rest/netutil.go
@@ -90,7 +90,7 @@ func (c *Client) GetQueryString(u *url.URL) {
 	return
 }
 
-// SetAuthHeaderOptins - set the Headers Options
+// SetAuthHeaderOptions - set the Headers Options
 func (c *Client) SetAuthHeaderOptions(headers map[string]string) {
 	c.Option.Headers = headers
 }

--- a/testconfig/pkginfo.go
+++ b/testconfig/pkginfo.go
@@ -25,7 +25,7 @@ func (i PackageInfo) ConvertOsPath(s string) string {
 	return s
 }
 
-// check if a dir exist
+// DirExists checks if a dir exist
 func (i PackageInfo) DirExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
@@ -37,7 +37,7 @@ func (i PackageInfo) DirExists(path string) (bool, error) {
 	return true, err
 }
 
-// Get the location of a package dir
+// GetPackageRootDir gets the location of a package dir
 // mostly useful for test cases
 func (i PackageInfo) GetPackageRootDir(package_path string) (exist bool, path string) {
 	for _, s := range strings.Split(os.Getenv("GOPATH"), string(os.PathListSeparator)) {

--- a/testconfig/testcases.go
+++ b/testconfig/testcases.go
@@ -94,7 +94,7 @@ func (tc *TestConfig) EqualFaceS(is interface{}, s string) bool {
 	return string(is.(string)) == string(s)
 }
 
-// Get a test case by name
+// GetTestCases gets a test case by name
 func (tc *TestConfig) GetTestCases(tc_name string) (t TestCases) {
 	for _, t := range tc.Cases {
 		if t.Name == tc_name {
@@ -104,7 +104,7 @@ func (tc *TestConfig) GetTestCases(tc_name string) (t TestCases) {
 	return t
 }
 
-// is test case enabled? defaults are always true
+// IsTestEnabled is test case enabled? defaults are always true
 func (tc *TestConfig) IsTestEnabled(tc_name string) bool {
 	if t := tc.GetTestCases(tc_name); t.Name == tc_name {
 		return t.Enabled
@@ -117,7 +117,7 @@ func (tc *TestConfig) IsTestEnabled(tc_name string) bool {
 	return true
 }
 
-// get expects data, returns interface because the data type is unknown
+// GetExpectsData gets expects data, returns interface because the data type is unknown
 // use tc Equal arguments for type comparison, conversions
 // or assert the type
 func (tc *TestConfig) GetExpectsData(tc_name string, k string) interface{} {
@@ -134,7 +134,7 @@ func (tc *TestConfig) GetExpectsData(tc_name string, k string) interface{} {
 	return nil
 }
 
-// get test data
+// GetTestData gets test data
 func (tc *TestConfig) GetTestData(tc_name string, k string) interface{} {
 	if t := tc.GetTestCases(tc_name); t.TestData[k] != nil {
 		log.Debugf("GetTestData(%s, %s) found -> %s", tc_name, k, t.TestData[k])

--- a/testconfig/testconfig.go
+++ b/testconfig/testconfig.go
@@ -32,7 +32,7 @@ func (tc *TestConfig) NewTestConfig() *TestConfig {
 		Cases: []TestCases{}}
 }
 
-// UnMarshall json to data
+// UnMarshallTestingConfig json to data
 func (tc *TestConfig) UnMarshallTestingConfig(json_data []byte) {
 	tc.Cases = []TestCases{}
 	if err := json.Unmarshal(json_data, &tc); err != nil {
@@ -41,7 +41,7 @@ func (tc *TestConfig) UnMarshallTestingConfig(json_data []byte) {
 	}
 }
 
-// get config for testing
+// GetTestingConfiguration gets config for testing
 // Examples
 // cv := tc.GetExpectsData("TestGetAPIVersion", "CurrentVersion")
 // log.Infof("tc test_data -> %s\n", tc.EqualFaceI(cv, 120))


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?