### PR TITLE
Enclosure - PartitionID Type to INT

### DIFF
--- a/ov/enclosure.go
+++ b/ov/enclosure.go
@@ -17,7 +17,7 @@ type Enclosure struct {
 	Category                                  string                `json:"category,omitempty"`                                  // "category": "enclosures",
 	Created                                   string                `json:"created,omitempty"`                                   // "created": "20150831T154835.250Z",
 	CrossBars                                 []CrossBar            `json:"crossBars,omitempty"`                                 // "crossBars": {},
-	Description                               string                `json:"description,omitempty"`                               // "description": "Enclosure Group 1",
+	Description                               utils.Nstring         `json:"description,omitempty"`                               // "description": "Enclosure Group 1",
 	DeviceBayCount                            int                   `json:"deviceBayCount,omitempty"`                            // "deviceBayCount": 16,
 	DeviceBays                                []DeviceBayMap        `json:"deviceBays,omitempty`                                 // "deviceBays": [],
 	DeviceBayWatts                            int                   `json:"deviceBayWatts,omitempty"`                            // "deviceBayWatts": 16,

--- a/ov/enclosure.go
+++ b/ov/enclosure.go
@@ -3,6 +3,7 @@ package ov
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/HewlettPackard/oneview-golang/rest"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/docker/machine/libmachine/log"
@@ -16,7 +17,7 @@ type Enclosure struct {
 	Category                                  string                `json:"category,omitempty"`                                  // "category": "enclosures",
 	Created                                   string                `json:"created,omitempty"`                                   // "created": "20150831T154835.250Z",
 	CrossBars                                 []CrossBar            `json:"crossBars,omitempty"`                                 // "crossBars": {},
-	Description                               utils.Nstring         `json:"description,omitempty"`                               // "description": "Enclosure Group 1",
+	Description                               string                `json:"description,omitempty"`                               // "description": "Enclosure Group 1",
 	DeviceBayCount                            int                   `json:"deviceBayCount,omitempty"`                            // "deviceBayCount": 16,
 	DeviceBays                                []DeviceBayMap        `json:"deviceBays,omitempty`                                 // "deviceBays": [],
 	DeviceBayWatts                            int                   `json:"deviceBayWatts,omitempty"`                            // "deviceBayWatts": 16,
@@ -247,7 +248,7 @@ type Partition struct {
 	MemoryMb          int           `json:"memoryMb,omitempty"`          // "memoryMb": 1,
 	MonarchDevice     int           `json:"monarchDevice,omitempty"`     // "monarchDevice": 1,
 	PartitionHealth   string        `json:"partitionHealth,omitempty"`   // "partitionHealth": "",
-	PartitionID       string        `json:"partitionID,omitempty"`       // "partitionID": "",
+	PartitionID       int           `json:"partitionID,omitempty"`       // "partitionID": "",
 	PartitionName     string        `json:"partitionName,omitempty"`     // "partitionName": "",
 	PartitionStatus   string        `json:"partitionStatus,omitempty"`   // "partitionStatus": "",
 	ParttionUUID      string        `json:"parttionUUID,omitempty"`      // "parttionUUID": "",


### PR DESCRIPTION
### Description
Change PartitionID Type from String to Int as described in the REST API Documentation

partitionID Numeric value of partition id within an enclosure. integer required read only

### Issues Resolved
None Documented

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
