### PR TITLE
Datatype change for Id in DeviceSpecificattributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)# 
 
 
+# [v7.2.0]
+#### Notes
+- This release extends supports of the SDK to Oneview API Version 4400.
+
+#### Bug fixes & Enhancements:
+- [#368] (https://github.com/HewlettPackard/oneview-golang/issues/368) GetStorageVolumes() Unmarshal Error
 
 # [v7.1.0]
 #### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)# 
 
 
-# [v7.2.0]
+# [v7.2.0](unreleased)
 #### Notes
 - This release extends supports of the SDK to Oneview API Version 4400.
 

--- a/ov/storage_volume.go
+++ b/ov/storage_volume.go
@@ -3,6 +3,7 @@ package ov
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/HewlettPackard/oneview-golang/rest"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/docker/machine/libmachine/log"
@@ -108,7 +109,7 @@ type DeviceSpecificAttributes struct {
 	Iqn                           string        `json:"iqn,omitempty"`
 	NumberOfReplicas              int           `json:"numberOfReplicas,omitempty"`
 	DataProtectionLevel           string        `json:"dataProtectionLevel,omitempty"`
-	Id                            int           `json:"id,omitempty"`
+	Id                            string        `json:"id,omitempty"`
 	Uri                           utils.Nstring `json:"uri,omitempty"`
 	CopyState                     string        `json:"copyState,omitempty"`
 	SnapshotPoolUri               utils.Nstring `json:"snapshotPoolUri,omitempty"`


### PR DESCRIPTION
### Description
Changes datatype of Id in DeviceSpecificAttributes struct to int to align it with oneview

### Issues Resolved
#368 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
