### PR TITLE
Update createtagandrelease.yml

### DIFF
--- a/.github/workflows/createtagandrelease.yml
+++ b/.github/workflows/createtagandrelease.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bump version and push tag
         id: tag_and_prepare_release
-        uses: moble/github-tag-action@main
+        uses: anothrNick/github-tag-action@1.64.0
         env:
-          GITHUB_TOKEN:  ${{ secrets.CD_TOKEN }}
+          GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          CUSTOM_TAG: "v7.2.0"
+          CUSTOM_TAG: "v8.4.0"
       - name: Display
         run: echo ${{ steps.tag_and_prepare_release.outputs.new_tag }}
       - uses: actions/checkout@v2
@@ -26,4 +26,4 @@ jobs:
           name:  ${{ steps.tag_and_prepare_release.outputs.new_tag }}
           tag: ${{ steps.tag_and_prepare_release.outputs.new_tag }}
           body: See the <a href="https://github.com/HewlettPackard/oneview-golang/blob/master/CHANGELOG.md">CHANGELOG.md</a> for details.
-          token:  ${{ secrets.CD_TOKEN }}
+          token:  ${{secrets.GITHUB_TOKEN}} 


### PR DESCRIPTION
### Description
Changed the github actions from moble/github actions to anthrNick create tag and release as the moble github actions does not exist in the github actions marketplace.
The token has been updated from CD_TOKEN to GITHUB_TOKEN.

### Issues Resolved
anothrNick create tag and release passed all tests and the token has been update

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
