### PR TITLE
Removing mirror list from FW bundle response

### DIFF
--- a/ov/firmware_drivers.go
+++ b/ov/firmware_drivers.go
@@ -43,7 +43,6 @@ type FirmwareDrivers struct {
 	IsoFileName           string              `json:"isoFileName,omitempty"`
 	LastTaskUri           string              `json:"lastTaskUri,omitempty"`
 	Locations             map[string]string   `json:"locations,omitempty"`
-	Mirrorlist            map[string][]string `json:"mirrorlist,omitempty"`
 	Modified              string              `json:"modified,omitempty"`
 	Name                  string              `json:"name,omitempty"`
 	ParentBundle          parentBundle        `json:"parentBundle,omitempty"`


### PR DESCRIPTION
### Description
This PR addresses an issue in the Terraform provider where firmware URIs referencing external repositories could not be read correctly. The problem stemmed from improper parsing of the mirrorList field, which caused all associated fields to be returned as null. As a result, even though the configuration structure was valid, the provider failed to reflect the actual state accurately.

Fix:
We are removing the use of the mirrorList attribute, as the required URIs are already accessible through another field. Since mirrorList is redundant in this context and causes issues with state reading, its removal simplifies the logic and ensures accurate state reflection in Terraform.

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]
https://github.com/HewlettPackard/terraform-provider-oneview/issues/570

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
