### PR TITLE
Changed datatype from int to *int for SecondaryServerPort

### DIFF
--- a/ov/profiles.go
+++ b/ov/profiles.go
@@ -141,7 +141,7 @@ type KeyManager struct {
 	PrimaryServerAddress   string `json:"-"`
 	PrimaryServerPort      int    `json:"-"`
 	SecondaryServerAddress string `json:"-"`
-	SecondaryServerPort    int    `json:"-"`
+	SecondaryServerPort    *int   `json:"-"`
 	RedundancyRequired     *bool  `json:"-"`
 	GroupName              string `json:"-"`
 	CertificateName        string `json:"-"`


### PR DESCRIPTION
### Description
Fixes an issue with ESKM configuration where SecondaryServerPort defaults to 0 when not specified, causing unintended behavior in OneView. Updated the field type from int to *int to allow nil values so the field is omitted from the payload unless explicitly set.

### Issues resolved-

https://jira-pro.it.hpe.com:8443/browse/CCSE-99452
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
